### PR TITLE
Add splitter dashboard

### DIFF
--- a/app/app.css
+++ b/app/app.css
@@ -1,6 +1,10 @@
 @import "tailwindcss";
 @import "@catppuccin/tailwindcss/mocha.css";
 
+.mocha {
+  color-scheme: dark;
+}
+
 @theme {
   --font-mono:
     "Chivo Mono", ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas,

--- a/app/env.d.ts
+++ b/app/env.d.ts
@@ -1,12 +1,14 @@
 export {};
 
+import type { Ai } from "@cloudflare/workers-types";
+
 declare module "react-router" {
   interface AppLoadContext {
     cloudflare: {
       env: {
         SUPABASE_URL: string;
         SUPABASE_ANON_KEY: string;
-        GOOGLE_CLOUD_VISION_API_KEY: string;
+        AI: Ai;
       };
       ctx: {
         waitUntil(promise: Promise<unknown>): void;

--- a/app/portfolio/routes/home.tsx
+++ b/app/portfolio/routes/home.tsx
@@ -8,6 +8,7 @@ export function meta(_args: Route.MetaArgs) {
   return [
     { title: "Tony Yuan" },
     { name: "description", content: "Tony Yuan's Portfolio" },
+    { name: "color-scheme", content: "dark" },
   ];
 }
 

--- a/app/splitter/AGENTS.md
+++ b/app/splitter/AGENTS.md
@@ -5,12 +5,14 @@ The splitter is a client-heavy bill-splitting app served at `/splitter/*`. It re
 ## Data model
 
 ```typescript
-Bill       = { title, participants: Participant[], items: Item[], tax, tip }
-Participant = { id, name, color: { bg, fg } }  // color is OKLCH pair from palette
-Item       = { id, name, price, splitBetween: string[] }  // splitBetween = participant IDs
+Bill        = { title, participants: Participant[], items: Item[], tax, tip }
+Participant = { id, name, color: PersonColor }
+PersonColor = { chip, avatar, text, button }  // Tailwind class strings from Catppuccin palette
+Item        = { id, name, price, splitBetween: string[], splitEvenly?: boolean }
+             // splitBetween = participant IDs; splitEvenly = always split among all participants
 
-LocalBill  = { id, bill, updatedAt, shareCode?, shareUrl? }  // stored in localStorage
-SharedBill = { shareCode, shareUrl, bill, cachedAt, expiresAt }  // cached in localStorage
+LocalBill   = { id, bill, updatedAt, shareCode?, shareUrl? }  // stored in localStorage
+SharedBill  = { shareCode, shareUrl, bill, cachedAt, expiresAt }  // cached in localStorage, 30-day TTL
 ```
 
 ## localStorage keys
@@ -21,7 +23,7 @@ SharedBill = { shareCode, shareUrl, bill, cachedAt, expiresAt }  // cached in lo
 | `splitter_shared_bills` | `SharedBill[]` — shared bills fetched from API, cached 30 days |
 | `splitter_settings`     | `SplitterSettings` — `{ skipShareDialog: boolean }`            |
 
-`useBillsStore` (`hooks/useBillsStore.ts`) is the single point of access for all localStorage reads/writes. It also handles legacy key migration from older formats.
+`useBillsStore` (`hooks/useBillsStore.ts`) is the single point of access for all localStorage reads/writes. It also handles legacy key migration from older formats (`splitter_bills`, `splitter_bill_draft`).
 
 ## State management
 
@@ -30,38 +32,51 @@ SharedBill = { shareCode, shareUrl, bill, cachedAt, expiresAt }  // cached in lo
 ## Share flow
 
 1. User clicks Share in `AppHeader`
-2. `SplitterShell.handleShare()` validates the bill (title, participants, items, all assigned)
+2. `SplitterShell.handleShare()` validates the bill via `canShareBill()` (requires: non-empty title, ≥1 participant, ≥1 item, all items have `splitBetween` assigned)
 3. If already shared: copies existing URL to clipboard
-4. If `skipShareDialog`: calls `confirmShare` directly
-5. Otherwise: opens `ShareDialog`
+4. If `skipShareDialog` is true: calls `confirmShare` directly
+5. Otherwise: opens `ShareDialog` modal
 6. `confirmShare` → `POST /api/share-bill` → Supabase `bill_shares` table → returns `{ url, code }`
-7. `LocalBill.shareCode` and `shareUrl` are set so future shares just copy the URL
+7. Shared bill is cached in `splitter_shared_bills`; local bill is deleted; user navigates to the read-only shared view
 
 ## API routes
 
 All API routes are in `routes/`. They run server-side on Cloudflare Workers.
 
-| Route                     | Purpose                                                     |
-| ------------------------- | ----------------------------------------------------------- |
-| `POST /api/share-bill`    | Stores bill JSON in `bill_shares` table, returns short code |
-| `GET /api/bill/:code`     | Fetches bill JSON by code                                   |
-| `POST /api/parse-receipt` | Google Cloud Vision OCR + Tesseract.js fallback             |
+| Route                     | Purpose                                                          |
+| ------------------------- | ---------------------------------------------------------------- |
+| `POST /api/share-bill`    | Stores bill JSON in `bill_shares` table, returns 6-char code     |
+| `GET /api/bill/:code`     | Fetches bill JSON by code                                        |
+| `POST /api/parse-receipt` | Cloudflare AI (Llama 3.2 11B Vision) OCR + Tesseract.js fallback |
 
 **OCR rate limits** (enforced via Supabase RPC `check_and_increment_ocr`): 10 requests/month per IP, 900/month global. Returns 429 on quota; client falls back to Tesseract.js.
 
+**EU regional blocking**: Returns 451 (Unavailable For Legal Reasons) for EU countries due to Llama 3.2 licensing; client falls back to Tesseract.js.
+
 ## Participant colors
 
-`utils/colors.ts` holds 8 OKLCH color pairs. `colorForIndex(n)` cycles through the palette. `nextColorSeed(participants)` finds the highest index in use so re-adding participants after removal never collides with existing colors.
+`utils/colors.ts` holds a 7-color Catppuccin palette. Each entry is a `PersonColor` with four Tailwind class strings (`chip`, `avatar`, `text`, `button`). `colorForIndex(n)` cycles through the palette. `nextColorSeed(participants)` finds the highest index in use so re-adding participants after removal never collides with existing colors.
 
 ## Key files
 
-| File                              | Role                                                             |
-| --------------------------------- | ---------------------------------------------------------------- |
-| `components/SplitterShell.tsx`    | Root component: all bill state + mutations                       |
-| `hooks/useBillsStore.ts`          | localStorage read/write + share flow + toast                     |
-| `types.ts`                        | All shared types                                                 |
-| `utils/colors.ts`                 | Participant color palette                                        |
-| `utils/parseReceiptText.ts`       | Text → `OcrItem[]` parser (used by both GCV and Tesseract paths) |
-| `routes/splitter.tsx`             | Index: redirects to latest bill or `/splitter/new`               |
-| `routes/splitter.$billId.tsx`     | Edit a local bill (clientLoader reads from localStorage)         |
-| `routes/splitter.share.$code.tsx` | View a shared bill (clientLoader fetches from API, caches)       |
+| File                              | Role                                                               |
+| --------------------------------- | ------------------------------------------------------------------ |
+| `types.ts`                        | All shared types                                                   |
+| `components/SplitterShell.tsx`    | Root component: all bill state + mutations                         |
+| `components/BillSummary.tsx`      | Per-person breakdown (tax/tip split proportionally by subtotal)    |
+| `hooks/useBillsStore.ts`          | localStorage read/write + share flow + toast                       |
+| `hooks/useReceiptOcr.ts`          | Receipt upload orchestration (server AI → Tesseract fallback)      |
+| `utils/bill.ts`                   | `canShareBill()` validation                                        |
+| `utils/colors.ts`                 | Participant color palette                                          |
+| `utils/parseReceiptText.ts`       | Text → `OcrItem[]` parser (used by both Llama and Tesseract paths) |
+| `routes/splitter.layout.tsx`      | Root layout: sidebar, toast system, `SplitterLayoutContext`        |
+| `routes/splitter.tsx`             | Dashboard: lists local drafts and shared bills                     |
+| `routes/splitter.new.tsx`         | New bill (generates UUID + redirects to `/$billId` on first edit)  |
+| `routes/splitter.$billId.tsx`     | Edit a local bill (clientLoader reads from localStorage)           |
+| `routes/splitter.share.$code.tsx` | View a shared bill (clientLoader fetches from API, caches 30d)     |
+
+## URL conventions
+
+- `/splitter/new?scan=1` — opens the receipt scan modal immediately on load
+- `/splitter/:billId` — edit a local bill
+- `/splitter/share/:code` — read-only view of a shared bill; shows "Fork" button to copy into a new local bill

--- a/app/splitter/components/AppHeader.tsx
+++ b/app/splitter/components/AppHeader.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { MdForkRight, MdMenu, MdShare } from "react-icons/md";
+import { MdForkRight, MdMenu, MdShare, MdScanner } from "react-icons/md";
 
 interface AppHeaderProps {
   title: string;
@@ -7,6 +7,7 @@ interface AppHeaderProps {
   onShare: () => void;
   onFork?: () => void;
   onMobileMenu: () => void;
+  onScanReceipt?: () => void;
   sharing: boolean;
   shareBlocked?: boolean;
   titleError?: boolean;
@@ -19,6 +20,7 @@ export function AppHeader({
   onShare,
   onFork,
   onMobileMenu,
+  onScanReceipt,
   sharing,
   shareBlocked = false,
   titleError = false,
@@ -59,6 +61,19 @@ export function AppHeader({
 
       {/* Actions */}
       <div className="flex shrink-0 items-center gap-2">
+        {/* Scan Receipt — single-column layout only */}
+        {onScanReceipt && (
+          <button
+            type="button"
+            onClick={onScanReceipt}
+            title="Scan receipt"
+            className="flex items-center gap-1.5 rounded-full border border-ctp-surface1/50 bg-ctp-surface0 px-3 py-1.5 text-xs font-semibold text-ctp-subtext1 transition-colors hover:border-ctp-teal/50 hover:bg-ctp-surface1 hover:text-ctp-teal min-[1160px]:hidden"
+          >
+            <MdScanner size={14} />
+            <span>Scan Receipt</span>
+          </button>
+        )}
+
         {/* Fork & Edit — shared view only */}
         {onFork && (
           <button

--- a/app/splitter/components/BillSidebar.tsx
+++ b/app/splitter/components/BillSidebar.tsx
@@ -135,9 +135,13 @@ export function BillSidebar({
       >
         {/* Logo */}
         <div className="border-b border-ctp-surface1/50 px-3 py-3 font-mono text-xl font-extrabold tracking-tight text-ctp-text">
-          <span className="inline-block h-7.5">
+          <Link
+            to="/splitter"
+            onClick={onClose}
+            className="inline-block h-7.5 transition hover:drop-shadow-[0_0_8px_#94e2d5]"
+          >
             splitter<span className="text-ctp-teal">.jhyn</span>
-          </span>
+          </Link>
         </div>
 
         {/* New Bill */}

--- a/app/splitter/components/BillSummary.tsx
+++ b/app/splitter/components/BillSummary.tsx
@@ -104,15 +104,18 @@ export function BillSummary({
   // Compute per-participant subtotals
   const subtotals: Record<string, number> = {};
   let totalSubtotal = 0;
+  let assignedSubtotal = 0;
 
   for (const item of items) {
+    if (isNaN(item.price)) continue;
+    totalSubtotal += item.price;
     const assigned = item.splitBetween;
-    if (assigned.length === 0 || isNaN(item.price)) continue;
+    if (assigned.length === 0) continue;
     const share = item.price / assigned.length;
     for (const pid of assigned) {
       subtotals[pid] = (subtotals[pid] ?? 0) + share;
     }
-    totalSubtotal += item.price;
+    assignedSubtotal += item.price;
   }
 
   const grandTotal = totalSubtotal + tax + tip;
@@ -121,7 +124,7 @@ export function BillSummary({
   const breakdowns: PersonBreakdown[] = participants.map((p) => {
     const sub = subtotals[p.id] ?? 0;
     const proportion =
-      totalSubtotal > 0 ? sub / totalSubtotal : 1 / participants.length;
+      assignedSubtotal > 0 ? sub / assignedSubtotal : 1 / participants.length;
     const myItems = items
       .filter((i) => i.splitBetween.includes(p.id) && !isNaN(i.price))
       .map((i) => ({

--- a/app/splitter/components/ReceiptUpload.tsx
+++ b/app/splitter/components/ReceiptUpload.tsx
@@ -1,9 +1,7 @@
 import { useRef, useState } from "react";
 import { MdScanner, MdChevronRight } from "react-icons/md";
-import {
-  parseReceiptText,
-  type OcrItem,
-} from "~/splitter/utils/parseReceiptText";
+import { useReceiptOcr } from "~/splitter/hooks/useReceiptOcr";
+import type { OcrItem } from "~/splitter/utils/parseReceiptText";
 
 interface ReceiptUploadProps {
   onImport: (items: OcrItem[], tax?: number, tip?: number) => void;
@@ -12,79 +10,13 @@ interface ReceiptUploadProps {
 
 export function ReceiptUpload({ onImport, hasContent }: ReceiptUploadProps) {
   const [expanded, setExpanded] = useState(!hasContent);
-  const [loading, setLoading] = useState(false);
-  const [status, setStatus] = useState<string | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
-
-  // Auto-collapse once content is added
-  if (hasContent && expanded && !loading) {
-    // Use a ref-free check — will collapse on next render after content added
-  }
-
-  async function handleFile(file: File) {
-    setLoading(true);
-    setStatus(null);
-
-    // Try GCV first
-    try {
-      const form = new FormData();
-      form.append("document", file);
-      const res = await fetch("/api/parse-receipt", {
-        method: "POST",
-        body: form,
-      });
-      if (res.ok) {
-        const data = (await res.json()) as {
-          items: OcrItem[];
-          tax?: number | null;
-          tip?: number | null;
-        };
-        if (data.items.length > 0) {
-          onImport(data.items, data.tax ?? undefined, data.tip ?? undefined);
-          setStatus(`Imported ${data.items.length} item(s). Please review.`);
-          setLoading(false);
-          setExpanded(false);
-          return;
-        }
-      }
-      if (res.status === 429) {
-        setStatus("Server quota reached — running local OCR…");
-      } else if (res.status === 451) {
-        setStatus("Running local OCR…");
-      }
-    } catch {
-      // fall through
-    }
-
-    // Tesseract.js fallback
-    try {
-      setStatus("Running local OCR (may take a moment)…");
-      const { createWorker } = await import("tesseract.js");
-      const worker = await createWorker("eng");
-      const {
-        data: { text },
-      } = await worker.recognize(file);
-      await worker.terminate();
-      const { items: parsed, tax, tip } = parseReceiptText(text);
-      if (parsed.length > 0) {
-        onImport(parsed, tax, tip);
-        setStatus(
-          `Imported ${parsed.length} item(s) via OCR — results are best-effort, please review.`,
-        );
-        setExpanded(false);
-      } else {
-        setStatus("Could not extract items. Try a clearer image.");
-      }
-    } catch {
-      setStatus("OCR failed. Please enter items manually.");
-    } finally {
-      setLoading(false);
-    }
-  }
+  const { loading, status, handleFile } = useReceiptOcr(onImport, () =>
+    setExpanded(false),
+  );
 
   return (
     <div className="overflow-hidden rounded-2xl border border-ctp-surface1/50 bg-ctp-surface0/40">
-      {/* Collapsible header */}
       <button
         type="button"
         onClick={() => !loading && setExpanded((e) => !e)}

--- a/app/splitter/components/ReceiptUpload.tsx
+++ b/app/splitter/components/ReceiptUpload.tsx
@@ -6,14 +6,11 @@ import {
 } from "~/splitter/utils/parseReceiptText";
 
 interface ReceiptUploadProps {
-  onItemsImported: (items: OcrItem[]) => void;
+  onImport: (items: OcrItem[], tax?: number, tip?: number) => void;
   hasContent: boolean;
 }
 
-export function ReceiptUpload({
-  onItemsImported,
-  hasContent,
-}: ReceiptUploadProps) {
+export function ReceiptUpload({ onImport, hasContent }: ReceiptUploadProps) {
   const [expanded, setExpanded] = useState(!hasContent);
   const [loading, setLoading] = useState(false);
   const [status, setStatus] = useState<string | null>(null);
@@ -37,9 +34,13 @@ export function ReceiptUpload({
         body: form,
       });
       if (res.ok) {
-        const data = (await res.json()) as { items: OcrItem[] };
+        const data = (await res.json()) as {
+          items: OcrItem[];
+          tax?: number | null;
+          tip?: number | null;
+        };
         if (data.items.length > 0) {
-          onItemsImported(data.items);
+          onImport(data.items, data.tax ?? undefined, data.tip ?? undefined);
           setStatus(`Imported ${data.items.length} item(s). Please review.`);
           setLoading(false);
           setExpanded(false);
@@ -47,7 +48,9 @@ export function ReceiptUpload({
         }
       }
       if (res.status === 429) {
-        setStatus("GCV quota reached — running local OCR…");
+        setStatus("Server quota reached — running local OCR…");
+      } else if (res.status === 451) {
+        setStatus("Running local OCR…");
       }
     } catch {
       // fall through
@@ -62,9 +65,9 @@ export function ReceiptUpload({
         data: { text },
       } = await worker.recognize(file);
       await worker.terminate();
-      const parsed = parseReceiptText(text);
+      const { items: parsed, tax, tip } = parseReceiptText(text);
       if (parsed.length > 0) {
-        onItemsImported(parsed);
+        onImport(parsed, tax, tip);
         setStatus(
           `Imported ${parsed.length} item(s) via OCR — results are best-effort, please review.`,
         );

--- a/app/splitter/components/ScanReceiptModal.tsx
+++ b/app/splitter/components/ScanReceiptModal.tsx
@@ -1,0 +1,85 @@
+import { useRef } from "react";
+import { MdClose, MdScanner } from "react-icons/md";
+import { useReceiptOcr } from "~/splitter/hooks/useReceiptOcr";
+import type { OcrItem } from "~/splitter/utils/parseReceiptText";
+
+interface ScanReceiptModalProps {
+  onImport: (items: OcrItem[], tax?: number, tip?: number) => void;
+  onClose: () => void;
+}
+
+export function ScanReceiptModal({ onImport, onClose }: ScanReceiptModalProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const { loading, status, handleFile } = useReceiptOcr(onImport, onClose);
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center p-4"
+      onClick={(e) => e.target === e.currentTarget && !loading && onClose()}
+    >
+      <div
+        className="absolute inset-0 bg-black/50 backdrop-blur-sm"
+        onClick={() => !loading && onClose()}
+      />
+
+      <div className="relative w-full max-w-sm rounded-2xl border border-ctp-surface1/50 bg-ctp-mantle shadow-2xl">
+        <div className="flex items-center justify-between border-b border-ctp-surface1/50 px-5 py-4">
+          <span className="text-[15px] font-bold text-ctp-text">
+            Scan Receipt
+          </span>
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={loading}
+            className="rounded-lg p-1 text-ctp-overlay0 transition-colors hover:bg-ctp-surface0 hover:text-ctp-text disabled:opacity-40"
+          >
+            <MdClose size={18} />
+          </button>
+        </div>
+
+        <div className="p-4">
+          {loading ? (
+            <div className="flex flex-col items-center gap-3 py-8">
+              <div className="h-8 w-8 animate-spin rounded-full border-2 border-ctp-surface1 border-t-ctp-teal" />
+              <p className="text-center text-sm text-ctp-subtext1">
+                {status ?? "Reading receipt…"}
+              </p>
+            </div>
+          ) : (
+            <>
+              <button
+                type="button"
+                onClick={() => inputRef.current?.click()}
+                className="flex w-full flex-col items-center gap-2 rounded-xl border-2 border-dashed border-ctp-surface1 bg-ctp-base/50 py-8 text-center transition-colors hover:border-ctp-teal/50 hover:bg-ctp-teal/5"
+              >
+                <MdScanner size={36} className="text-ctp-overlay0" />
+                <span className="text-sm font-semibold text-ctp-subtext0">
+                  Tap to upload your receipt
+                </span>
+                <span className="text-xs text-ctp-overlay0">
+                  JPG, PNG, HEIC
+                </span>
+              </button>
+              {status && (
+                <p className="mt-3 text-center text-xs text-ctp-subtext1">
+                  {status}
+                </p>
+              )}
+            </>
+          )}
+          <input
+            ref={inputRef}
+            type="file"
+            accept="image/*"
+            className="hidden"
+            onChange={(e) => {
+              const file = e.target.files?.[0];
+              if (file) handleFile(file);
+              e.target.value = "";
+            }}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/splitter/components/SplitterShell.tsx
+++ b/app/splitter/components/SplitterShell.tsx
@@ -6,10 +6,12 @@ import { AppHeader } from "~/splitter/components/AppHeader";
 import { BillSummary } from "~/splitter/components/BillSummary";
 import { ItemSection } from "~/splitter/components/ItemSection";
 import { ParticipantSection } from "~/splitter/components/ParticipantSection";
+import { ReceiptUpload } from "~/splitter/components/ReceiptUpload";
 import { ShareDialog } from "~/splitter/components/ShareDialog";
 import { TaxTip } from "~/splitter/components/TaxTip";
 import type { SplitterLayoutContext } from "~/splitter/routes/splitter.layout";
 import type { Bill, Item, LocalBill, SharedBill } from "~/splitter/types";
+import type { OcrItem } from "~/splitter/utils/parseReceiptText";
 
 interface SplitterShellProps {
   initialLocalBill: LocalBill | null;
@@ -123,6 +125,20 @@ export function SplitterShell({
 
   function removeItem(id: string) {
     mutate({ items: items.filter((item) => item.id !== id) });
+  }
+
+  function handleImport(ocrItems: OcrItem[], ocrTax?: number, ocrTip?: number) {
+    const newItems: Item[] = ocrItems.map(({ description, total_amount }) => ({
+      id: crypto.randomUUID(),
+      name: description,
+      price: total_amount,
+      splitBetween: [],
+    }));
+    mutate({
+      items: [...items, ...newItems],
+      ...(ocrTax !== undefined ? { tax: ocrTax } : {}),
+      ...(ocrTip !== undefined ? { tip: ocrTip } : {}),
+    });
   }
 
   function handleFork() {
@@ -239,6 +255,12 @@ export function SplitterShell({
               readOnly={isSharedView}
               showError={shareAttempted && participants.length === 0}
             />
+            {!isSharedView && (
+              <ReceiptUpload
+                onImport={handleImport}
+                hasContent={items.length > 0}
+              />
+            )}
             <ItemSection
               items={items}
               participants={participants}

--- a/app/splitter/components/SplitterShell.tsx
+++ b/app/splitter/components/SplitterShell.tsx
@@ -7,6 +7,7 @@ import { BillSummary } from "~/splitter/components/BillSummary";
 import { ItemSection } from "~/splitter/components/ItemSection";
 import { ParticipantSection } from "~/splitter/components/ParticipantSection";
 import { ReceiptUpload } from "~/splitter/components/ReceiptUpload";
+import { ScanReceiptModal } from "~/splitter/components/ScanReceiptModal";
 import { ShareDialog } from "~/splitter/components/ShareDialog";
 import { TaxTip } from "~/splitter/components/TaxTip";
 import type { SplitterLayoutContext } from "~/splitter/routes/splitter.layout";
@@ -44,6 +45,7 @@ export function SplitterShell({
   const [savedBillId, setSavedBillId] = useState<string | null>(
     initialLocalBill?.id ?? null,
   );
+  const [scanModalOpen, setScanModalOpen] = useState(false);
   const isFirstMutation = useRef(!savedBillId && isNew);
   // Only ever increments — never decremented on removal — so re-adds after
   // removals always get a fresh color rather than colliding with an existing one.
@@ -219,6 +221,12 @@ export function SplitterShell({
 
   return (
     <>
+      {scanModalOpen && (
+        <ScanReceiptModal
+          onImport={handleImport}
+          onClose={() => setScanModalOpen(false)}
+        />
+      )}
       <ShareDialog
         open={store.shareDialogOpen}
         sharing={store.sharing}
@@ -239,6 +247,7 @@ export function SplitterShell({
         onShare={handleShare}
         onFork={isSharedView ? handleFork : undefined}
         onMobileMenu={onMobileMenu}
+        onScanReceipt={!isSharedView ? () => setScanModalOpen(true) : undefined}
         sharing={store.sharing}
         shareBlocked={shareBlocked}
         titleError={shareAttempted && !title.trim()}
@@ -246,8 +255,8 @@ export function SplitterShell({
       />
 
       <div className="flex-1 overflow-y-auto">
-        <div className="mx-auto grid max-w-300 grid-cols-1 gap-7 px-5 py-8 md:grid-cols-[1fr_360px] lg:px-8">
-          <div className="flex flex-col gap-8">
+        <div className="mx-auto grid max-w-300 grid-cols-1 gap-7 px-5 py-8 lg:px-8 min-[1160px]:grid-cols-[1fr_360px]">
+          <div className="flex min-w-0 flex-col gap-8">
             <ParticipantSection
               participants={participants}
               onAdd={addParticipant}
@@ -255,12 +264,6 @@ export function SplitterShell({
               readOnly={isSharedView}
               showError={shareAttempted && participants.length === 0}
             />
-            {!isSharedView && (
-              <ReceiptUpload
-                onImport={handleImport}
-                hasContent={items.length > 0}
-              />
-            )}
             <ItemSection
               items={items}
               participants={participants}
@@ -285,7 +288,15 @@ export function SplitterShell({
             )}
           </div>
 
-          <div className="flex flex-col gap-5 md:sticky md:top-4 md:self-start">
+          <div className="flex min-w-0 flex-col gap-5 min-[1160px]:sticky min-[1160px]:top-4 min-[1160px]:self-start">
+            {!isSharedView && (
+              <div className="hidden min-[1160px]:block">
+                <ReceiptUpload
+                  onImport={handleImport}
+                  hasContent={items.length > 0}
+                />
+              </div>
+            )}
             <BillSummary
               items={items}
               participants={participants}

--- a/app/splitter/components/SplitterShell.tsx
+++ b/app/splitter/components/SplitterShell.tsx
@@ -1,5 +1,10 @@
 import { useRef, useState } from "react";
-import { useNavigate, useOutletContext } from "react-router";
+import {
+  useLocation,
+  useNavigate,
+  useOutletContext,
+  useSearchParams,
+} from "react-router";
 import { canShareBill } from "~/splitter/utils/bill";
 import { colorForIndex, nextColorSeed } from "~/splitter/utils/colors";
 import { AppHeader } from "~/splitter/components/AppHeader";
@@ -28,6 +33,8 @@ export function SplitterShell({
   error,
 }: SplitterShellProps) {
   const navigate = useNavigate();
+  const location = useLocation();
+  const [searchParams] = useSearchParams();
   const { store, onMobileMenu } = useOutletContext<SplitterLayoutContext>();
   const [shareAttempted, setShareAttempted] = useState(false);
 
@@ -45,7 +52,9 @@ export function SplitterShell({
   const [savedBillId, setSavedBillId] = useState<string | null>(
     initialLocalBill?.id ?? null,
   );
-  const [scanModalOpen, setScanModalOpen] = useState(false);
+  const [scanModalOpen, setScanModalOpen] = useState(
+    () => searchParams.get("scan") === "1",
+  );
   const isFirstMutation = useRef(!savedBillId && isNew);
   // Only ever increments — never decremented on removal — so re-adds after
   // removals always get a fresh color rather than colliding with an existing one.
@@ -224,7 +233,12 @@ export function SplitterShell({
       {scanModalOpen && (
         <ScanReceiptModal
           onImport={handleImport}
-          onClose={() => setScanModalOpen(false)}
+          onClose={() => {
+            setScanModalOpen(false);
+            if (searchParams.get("scan") === "1") {
+              navigate(location.pathname, { replace: true });
+            }
+          }}
         />
       )}
       <ShareDialog

--- a/app/splitter/components/Toggle.tsx
+++ b/app/splitter/components/Toggle.tsx
@@ -1,0 +1,54 @@
+interface ToggleProps {
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+  label?: string;
+  description?: string;
+  disabled?: boolean;
+}
+
+export function Toggle({
+  checked,
+  onChange,
+  label,
+  description,
+  disabled = false,
+}: ToggleProps) {
+  const track = (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      disabled={disabled}
+      onClick={() => onChange(!checked)}
+      className={[
+        "relative h-6 w-11 shrink-0 rounded-full transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ctp-teal focus-visible:ring-offset-2 focus-visible:ring-offset-ctp-base",
+        checked ? "bg-ctp-teal" : "bg-ctp-surface2",
+        disabled ? "cursor-not-allowed opacity-50" : "",
+      ]
+        .filter(Boolean)
+        .join(" ")}
+    >
+      {/* left-0.5 = 2px base; +translate-x-5 (20px) on → 22px from left, 2px gap each side */}
+      <span
+        className={[
+          "absolute top-0.5 left-0.5 h-5 w-5 rounded-full bg-white shadow transition-transform",
+          checked ? "translate-x-5" : "translate-x-0",
+        ].join(" ")}
+      />
+    </button>
+  );
+
+  if (!label) return track;
+
+  return (
+    <div className="flex items-center justify-between gap-4">
+      <div>
+        <div className="font-semibold text-ctp-text">{label}</div>
+        {description && (
+          <div className="mt-0.5 text-sm text-ctp-subtext0">{description}</div>
+        )}
+      </div>
+      {track}
+    </div>
+  );
+}

--- a/app/splitter/hooks/useReceiptOcr.ts
+++ b/app/splitter/hooks/useReceiptOcr.ts
@@ -1,0 +1,74 @@
+import { useState } from "react";
+import {
+  parseReceiptText,
+  type OcrItem,
+} from "~/splitter/utils/parseReceiptText";
+
+export function useReceiptOcr(
+  onImport: (items: OcrItem[], tax?: number, tip?: number) => void,
+  onSuccess?: () => void,
+) {
+  const [loading, setLoading] = useState(false);
+  const [status, setStatus] = useState<string | null>(null);
+
+  async function handleFile(file: File) {
+    setLoading(true);
+    setStatus(null);
+
+    try {
+      const form = new FormData();
+      form.append("document", file);
+      const res = await fetch("/api/parse-receipt", {
+        method: "POST",
+        body: form,
+      });
+      if (res.ok) {
+        const data = (await res.json()) as {
+          items: OcrItem[];
+          tax?: number | null;
+          tip?: number | null;
+        };
+        if (data.items.length > 0) {
+          onImport(data.items, data.tax ?? undefined, data.tip ?? undefined);
+          setStatus(`Imported ${data.items.length} item(s). Please review.`);
+          setLoading(false);
+          onSuccess?.();
+          return;
+        }
+      }
+      if (res.status === 429) {
+        setStatus("Server quota reached — running local OCR…");
+      } else if (res.status === 451) {
+        setStatus("Running local OCR…");
+      }
+    } catch {
+      // fall through to Tesseract
+    }
+
+    try {
+      setStatus("Running local OCR (may take a moment)…");
+      const { createWorker } = await import("tesseract.js");
+      const worker = await createWorker("eng");
+      const {
+        data: { text },
+      } = await worker.recognize(file);
+      await worker.terminate();
+      const { items: parsed, tax, tip } = parseReceiptText(text);
+      if (parsed.length > 0) {
+        onImport(parsed, tax, tip);
+        setStatus(
+          `Imported ${parsed.length} item(s) via OCR — results are best-effort, please review.`,
+        );
+        onSuccess?.();
+      } else {
+        setStatus("Could not extract items. Try a clearer image.");
+      }
+    } catch {
+      setStatus("OCR failed. Please enter items manually.");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return { loading, status, handleFile };
+}

--- a/app/splitter/routes/api.parse-receipt.ts
+++ b/app/splitter/routes/api.parse-receipt.ts
@@ -11,10 +11,58 @@ async function sha256hex(input: string): Promise<string> {
     .slice(0, 16);
 }
 
+// Llama 3.2 license prohibits use for EU-domiciled individuals
+const EU_COUNTRIES = new Set([
+  "AT",
+  "BE",
+  "BG",
+  "CY",
+  "CZ",
+  "DE",
+  "DK",
+  "EE",
+  "ES",
+  "FI",
+  "FR",
+  "GR",
+  "HR",
+  "HU",
+  "IE",
+  "IT",
+  "LT",
+  "LU",
+  "LV",
+  "MT",
+  "NL",
+  "PL",
+  "PT",
+  "RO",
+  "SE",
+  "SI",
+  "SK",
+]);
+
+const PROMPT = `You are reading a receipt image. Output one entry per line using this exact format:
+  <name>  <price>
+
+Rules:
+- Include purchased items and discounts (discounts as negative prices, e.g. "Promo  -5.00")
+- Include tax on its own line as "Tax  <amount>"
+- Include tip or gratuity on its own line as "Tip  <amount>"
+- Exclude totals, subtotals, balance due, change, and any row that sums up other rows — even if labelled AMT, TOTAL AMT, DUE, BALANCE, etc.
+- No currency symbols, no explanations, no blank lines
+
+Example output:
+Burger  12.99
+Fries  4.99
+Promo  -5.00
+Tax  1.50
+Tip  3.00`;
+
 export async function action({ request, context }: Route.ActionArgs) {
-  const apiKey = context.cloudflare.env.GOOGLE_CLOUD_VISION_API_KEY;
-  if (!apiKey) {
-    return Response.json({ error: "GCV not configured" }, { status: 503 });
+  const country = request.headers.get("CF-IPCountry") ?? "";
+  if (EU_COUNTRIES.has(country)) {
+    return Response.json({ error: "EU region" }, { status: 451 });
   }
 
   const ip = request.headers.get("CF-Connecting-IP") ?? "unknown";
@@ -43,33 +91,33 @@ export async function action({ request, context }: Route.ActionArgs) {
   }
 
   const buffer = await (file as File).arrayBuffer();
-  const base64 = btoa(String.fromCharCode(...new Uint8Array(buffer)));
-
-  const res = await fetch(
-    `https://vision.googleapis.com/v1/images:annotate?key=${apiKey}`,
-    {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        requests: [
-          {
-            image: { content: base64 },
-            features: [{ type: "DOCUMENT_TEXT_DETECTION" }],
-          },
-        ],
-      }),
-    },
-  );
-
-  if (!res.ok) {
-    return Response.json({ error: "GCV error" }, { status: res.status });
+  const bytes = new Uint8Array(buffer);
+  let binary = "";
+  for (let i = 0; i < bytes.byteLength; i++) {
+    binary += String.fromCharCode(bytes[i]);
   }
+  const base64 = btoa(binary);
+  const mimeType = (file as File).type || "image/jpeg";
 
-  const json = (await res.json()) as {
-    responses?: Array<{
-      textAnnotations?: Array<{ description?: string }>;
-    }>;
-  };
-  const text = json.responses?.[0]?.textAnnotations?.[0]?.description ?? "";
-  return Response.json({ items: parseReceiptText(text) });
+  const aiResponse = (await context.cloudflare.env.AI.run(
+    "@cf/meta/llama-3.2-11b-vision-instruct",
+    {
+      messages: [
+        {
+          role: "user",
+          content: [
+            { type: "text", text: PROMPT },
+            {
+              type: "image_url",
+              image_url: { url: `data:${mimeType};base64,${base64}` },
+            },
+          ],
+        },
+      ],
+      max_tokens: 1024,
+    },
+  )) as { response: string };
+
+  const { items, tax, tip } = parseReceiptText(aiResponse.response);
+  return Response.json({ items, tax, tip });
 }

--- a/app/splitter/routes/splitter.settings.tsx
+++ b/app/splitter/routes/splitter.settings.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { useNavigate, useOutletContext } from "react-router";
 import type { Route } from "./+types/splitter.settings";
+import { Toggle } from "~/splitter/components/Toggle";
 import type { SplitterLayoutContext } from "~/splitter/routes/splitter.layout";
 
 export function meta(_args: Route.MetaArgs) {
@@ -58,41 +59,12 @@ export default function SplitterSettingsPage() {
         <div className="mx-auto max-w-xl px-5 py-8 lg:px-8">
           <div className="flex flex-col gap-6">
             <div className="rounded-2xl border border-ctp-surface1/50 bg-ctp-surface0/40 p-5">
-              <div className="flex items-center justify-between gap-4">
-                <div>
-                  <div className="font-semibold text-ctp-text">
-                    Skip share confirmation
-                  </div>
-                  <div className="mt-0.5 text-sm text-ctp-subtext0">
-                    Share links without showing the warning dialog each time.
-                  </div>
-                </div>
-                <button
-                  type="button"
-                  onClick={() =>
-                    store.updateSettings({
-                      skipShareDialog: !store.settings.skipShareDialog,
-                    })
-                  }
-                  className={[
-                    "relative h-6 w-11 shrink-0 rounded-full transition-colors",
-                    store.settings.skipShareDialog
-                      ? "bg-ctp-teal"
-                      : "bg-ctp-surface2",
-                  ].join(" ")}
-                  role="switch"
-                  aria-checked={store.settings.skipShareDialog}
-                >
-                  <span
-                    className={[
-                      "absolute top-0.5 h-5 w-5 rounded-full bg-white shadow transition-transform",
-                      store.settings.skipShareDialog
-                        ? "translate-x-5"
-                        : "translate-x-0.5",
-                    ].join(" ")}
-                  />
-                </button>
-              </div>
+              <Toggle
+                checked={store.settings.skipShareDialog}
+                onChange={(v) => store.updateSettings({ skipShareDialog: v })}
+                label="Skip share confirmation"
+                description="Share links without showing the warning dialog each time."
+              />
             </div>
 
             <div className="rounded-2xl border border-ctp-surface1/50 bg-ctp-surface0/40 p-5">

--- a/app/splitter/routes/splitter.share.$code.tsx
+++ b/app/splitter/routes/splitter.share.$code.tsx
@@ -91,6 +91,7 @@ export default function SplitterSharePage({
 }: Route.ComponentProps) {
   return (
     <SplitterShell
+      key={loaderData.sharedBill?.shareCode ?? "error"}
       initialLocalBill={null}
       sharedBill={loaderData.sharedBill}
       error={loaderData.error}

--- a/app/splitter/routes/splitter.tsx
+++ b/app/splitter/routes/splitter.tsx
@@ -1,6 +1,8 @@
-import { redirect } from "react-router";
+import { Link, useOutletContext } from "react-router";
+import { MdAdd, MdMenu, MdScanner } from "react-icons/md";
 import type { Route } from "./+types/splitter";
-import type { LocalBill } from "~/splitter/types";
+import type { SplitterLayoutContext } from "~/splitter/routes/splitter.layout";
+import type { LocalBill, SharedBill } from "~/splitter/types";
 
 export function meta(_args: Route.MetaArgs) {
   return [
@@ -12,18 +14,8 @@ export function meta(_args: Route.MetaArgs) {
   ];
 }
 
-export function clientLoader(): Response {
-  try {
-    const raw = localStorage.getItem("splitter_local_bills");
-    const bills: LocalBill[] = raw ? JSON.parse(raw) : [];
-    const latest = bills.sort((a, b) => b.updatedAt - a.updatedAt)[0];
-    if (latest) {
-      return redirect(`/splitter/${latest.id}`);
-    }
-  } catch {
-    // fall through
-  }
-  return redirect("/splitter/new");
+export function clientLoader() {
+  return {};
 }
 
 export function HydrateFallback() {
@@ -34,6 +26,207 @@ export function HydrateFallback() {
   );
 }
 
-export default function SplitterIndex() {
-  return null;
+function relativeTime(ts: number): string {
+  const diff = Date.now() - ts;
+  const mins = Math.floor(diff / 60_000);
+  if (mins < 1) return "just now";
+  if (mins < 60) return `${mins}m ago`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 7) return `${days}d ago`;
+  return new Date(ts).toLocaleDateString();
+}
+
+function ParticipantAvatars({
+  participants,
+}: {
+  participants: LocalBill["bill"]["participants"];
+}) {
+  const max = 4;
+  const visible = participants.slice(0, max);
+  const overflow = participants.length - max;
+
+  return (
+    <div className="flex items-center -space-x-1.5">
+      {visible.map((p) => (
+        <div
+          key={p.id}
+          className={`flex h-5 w-5 shrink-0 items-center justify-center rounded-full text-[10px] font-bold ring-1 ring-ctp-base ${p.color.avatar}`}
+          title={p.name}
+        >
+          {p.name.charAt(0).toUpperCase() || "?"}
+        </div>
+      ))}
+      {overflow > 0 && (
+        <div className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-ctp-surface1 text-[10px] font-bold text-ctp-subtext1 ring-1 ring-ctp-base">
+          +{overflow}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function DraftCard({ bill }: { bill: LocalBill }) {
+  const itemCount = bill.bill.items.length;
+  const personCount = bill.bill.participants.length;
+
+  return (
+    <Link
+      to={`/splitter/${bill.id}`}
+      className="group flex flex-col gap-3 rounded-xl border border-ctp-surface1/50 bg-ctp-surface0/40 p-4 transition-colors hover:border-ctp-teal/40 hover:bg-ctp-surface0/70"
+    >
+      <div className="flex items-start justify-between gap-2">
+        <p className="truncate font-mono text-sm font-semibold text-ctp-text transition-colors group-hover:text-ctp-teal">
+          {bill.bill.title || "Untitled Bill"}
+        </p>
+        {bill.shareCode && (
+          <span className="shrink-0 rounded-full border border-ctp-teal/20 bg-ctp-teal/10 px-2 py-0.5 text-[10px] font-semibold text-ctp-teal">
+            Shared
+          </span>
+        )}
+      </div>
+      {personCount > 0 && (
+        <ParticipantAvatars participants={bill.bill.participants} />
+      )}
+      <div className="mt-auto flex items-center justify-between">
+        <p className="text-xs text-ctp-overlay0">
+          {itemCount} item{itemCount !== 1 ? "s" : ""} · {personCount}{" "}
+          {personCount !== 1 ? "people" : "person"}
+        </p>
+        <p className="text-xs text-ctp-overlay0">
+          {relativeTime(bill.updatedAt)}
+        </p>
+      </div>
+    </Link>
+  );
+}
+
+function SharedCard({ bill }: { bill: SharedBill }) {
+  const itemCount = bill.bill.items.length;
+  const personCount = bill.bill.participants.length;
+
+  return (
+    <Link
+      to={`/splitter/share/${bill.shareCode}`}
+      className="group flex flex-col gap-3 rounded-xl border border-ctp-surface1/50 bg-ctp-surface0/40 p-4 transition-colors hover:border-ctp-mauve/40 hover:bg-ctp-surface0/70"
+    >
+      <p className="truncate font-mono text-sm font-semibold text-ctp-text transition-colors group-hover:text-ctp-mauve">
+        {bill.bill.title || "Untitled Bill"}
+      </p>
+      {personCount > 0 && (
+        <ParticipantAvatars participants={bill.bill.participants} />
+      )}
+      <div className="mt-auto flex items-center justify-between">
+        <p className="text-xs text-ctp-overlay0">
+          {itemCount} item{itemCount !== 1 ? "s" : ""} · {personCount}{" "}
+          {personCount !== 1 ? "people" : "person"}
+        </p>
+        <p className="text-xs text-ctp-overlay0">
+          {relativeTime(bill.cachedAt)}
+        </p>
+      </div>
+    </Link>
+  );
+}
+
+export default function SplitterDashboard() {
+  const { store, onMobileMenu } = useOutletContext<SplitterLayoutContext>();
+
+  const sortedLocal = [...store.localBills].sort(
+    (a, b) => b.updatedAt - a.updatedAt,
+  );
+  const sortedShared = [...store.sharedBills].sort(
+    (a, b) => b.cachedAt - a.cachedAt,
+  );
+  const hasBills = sortedLocal.length > 0 || sortedShared.length > 0;
+
+  return (
+    <div className="flex flex-1 flex-col overflow-hidden">
+      {/* Mobile-only header */}
+      <header className="flex items-center gap-3 border-b border-ctp-surface1/50 bg-ctp-base/85 px-4 py-3 backdrop-blur-md md:hidden">
+        <button
+          type="button"
+          onClick={onMobileMenu}
+          className="shrink-0 rounded-lg p-1.5 text-ctp-subtext1 transition-colors hover:bg-ctp-surface0 hover:text-ctp-text"
+          aria-label="Open menu"
+        >
+          <MdMenu size={20} />
+        </button>
+        <span className="font-mono text-lg font-extrabold text-ctp-text">
+          splitter<span className="text-ctp-teal">.jhyn</span>
+        </span>
+      </header>
+
+      {/* Content */}
+      <div className="flex-1 overflow-y-auto px-4 py-8 sm:px-6">
+        <div className="mx-auto flex max-w-2xl flex-col gap-10">
+          {/* CTA */}
+          <div
+            className={[
+              "flex flex-col items-center rounded-2xl border border-ctp-surface1/50 bg-ctp-surface0/30 px-8 text-center",
+              hasBills ? "py-10" : "py-16",
+            ].join(" ")}
+          >
+            <p className="mb-1 font-mono text-2xl font-extrabold text-ctp-text">
+              Split a bill
+            </p>
+            <p className="mb-8 text-sm text-ctp-subtext0">
+              No login required · Bills auto-save locally
+            </p>
+            <div className="flex flex-wrap items-center justify-center gap-3">
+              <Link
+                to="/splitter/new"
+                className="flex items-center gap-2 rounded-full bg-ctp-teal px-6 py-3 text-sm font-bold text-ctp-base transition-opacity hover:opacity-90"
+              >
+                <MdAdd size={18} />
+                New Bill
+              </Link>
+              <Link
+                to="/splitter/new?scan=1"
+                className="flex items-center gap-2 rounded-full border border-ctp-surface1/50 bg-ctp-surface0 px-6 py-3 text-sm font-semibold text-ctp-subtext1 transition-colors hover:border-ctp-teal/50 hover:bg-ctp-surface1 hover:text-ctp-teal"
+              >
+                <MdScanner size={18} />
+                Scan Receipt
+              </Link>
+            </div>
+          </div>
+
+          {/* Drafts */}
+          {sortedLocal.length > 0 && (
+            <section className="flex flex-col gap-3">
+              <h2 className="text-xs font-bold uppercase tracking-wider text-ctp-overlay0">
+                Drafts
+                <span className="ml-1.5 text-ctp-overlay1">
+                  ({sortedLocal.length})
+                </span>
+              </h2>
+              <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+                {sortedLocal.map((b) => (
+                  <DraftCard key={b.id} bill={b} />
+                ))}
+              </div>
+            </section>
+          )}
+
+          {/* Shared */}
+          {sortedShared.length > 0 && (
+            <section className="flex flex-col gap-3">
+              <h2 className="text-xs font-bold uppercase tracking-wider text-ctp-overlay0">
+                Shared
+                <span className="ml-1.5 text-ctp-overlay1">
+                  ({sortedShared.length})
+                </span>
+              </h2>
+              <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+                {sortedShared.map((b) => (
+                  <SharedCard key={b.shareCode} bill={b} />
+                ))}
+              </div>
+            </section>
+          )}
+        </div>
+      </div>
+    </div>
+  );
 }

--- a/app/splitter/utils/parseReceiptText.ts
+++ b/app/splitter/utils/parseReceiptText.ts
@@ -1,22 +1,38 @@
 export type OcrItem = { description: string; total_amount: number };
 
-const pricePattern = /^(.+?)\s+\$?([\d]+\.[\d]{2})\s*$/;
-const skipWords =
-  /total|tax|tip|subtotal|gratuity|discount|change|balance|amount|due/i;
+export type ParsedReceipt = {
+  items: OcrItem[];
+  tax?: number;
+  tip?: number;
+};
 
-export function parseReceiptText(text: string): OcrItem[] {
+const pricePattern = /^(.+?)\s+(-?\$?[\d]+\.[\d]{2})\s*$/;
+const skipWords = /total|subtotal|change|balance|amount|due/i;
+const taxPattern = /\btax\b/i;
+const tipPattern = /\btip\b|\bgratuity\b/i;
+
+export function parseReceiptText(text: string): ParsedReceipt {
   const items: OcrItem[] = [];
+  let tax: number | undefined;
+  let tip: number | undefined;
+
   for (const line of text.split("\n")) {
     const trimmed = line.trim();
     if (!trimmed || skipWords.test(trimmed)) continue;
     const match = trimmed.match(pricePattern);
-    if (match) {
-      const description = match[1].trim();
-      const total_amount = parseFloat(match[2]);
-      if (description.length > 1 && total_amount > 0 && total_amount < 10000) {
-        items.push({ description, total_amount });
-      }
+    if (!match) continue;
+    const description = match[1].trim();
+    const amount = parseFloat(match[2].replace("$", ""));
+    if (isNaN(amount) || Math.abs(amount) >= 10000) continue;
+
+    if (taxPattern.test(trimmed) && amount > 0) {
+      tax = amount;
+    } else if (tipPattern.test(trimmed) && amount > 0) {
+      tip = amount;
+    } else if (description.length > 1 && amount !== 0) {
+      items.push({ description, total_amount: amount });
     }
   }
-  return items;
+
+  return { items, tax, tip };
 }

--- a/workers/app.ts
+++ b/workers/app.ts
@@ -1,4 +1,5 @@
 import { createRequestHandler } from "react-router";
+import type { Ai } from "@cloudflare/workers-types";
 
 const requestHandler = createRequestHandler(
   () => import("virtual:react-router/server-build"),
@@ -8,7 +9,7 @@ const requestHandler = createRequestHandler(
 type CloudflareEnv = {
   SUPABASE_URL: string;
   SUPABASE_ANON_KEY: string;
-  GOOGLE_CLOUD_VISION_API_KEY: string;
+  AI: Ai;
 };
 
 type CloudflareCtx = {

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -8,5 +8,8 @@
   "main": "./workers/app.ts",
   "compatibility_flags": [
     "nodejs_compat"
-  ]
+  ],
+  "ai": {
+    "binding": "AI"
+  }
 }


### PR DESCRIPTION
## Summary

- Replaces the auto-redirect on `/splitter` with a landing dashboard showing draft and shared bill cards
- Large CTA with **New Bill** and **Scan Receipt** buttons (scan navigates to `/splitter/new?scan=1` and auto-opens the modal; closing the modal cleans up the URL param)
- Sidebar logo now links back to `/splitter` with a teal glow on hover
- Mobile gets a header strip with hamburger + logo; desktop shows no header (sidebar already has the logo)

## Test plan

- [ ] Visit `/splitter` — dashboard renders with CTA and bill cards for any existing drafts/shared bills
- [ ] Click **New Bill** → navigates to `/splitter/new`
- [ ] Click **Scan Receipt** → navigates to `/splitter/new?scan=1` and scan modal opens immediately; closing it strips `?scan=1` from URL
- [ ] Click sidebar logo → navigates back to `/splitter`
- [ ] On mobile: logo and hamburger appear in the dashboard header; sidebar logo still links home

🤖 Generated with [Claude Code](https://claude.com/claude-code)