### PR TITLE
Fix spurious 429s when scanning receipts

### DIFF
--- a/app/splitter/routes/api.parse-receipt.ts
+++ b/app/splitter/routes/api.parse-receipt.ts
@@ -80,11 +80,15 @@ export async function action({ request, context }: Route.ActionArgs) {
   );
   const month = new Date().toISOString().slice(0, 7);
 
-  const { data } = await supabase.rpc("check_and_increment_ocr", {
+  const { data, error } = await supabase.rpc("check_and_increment_ocr", {
     p_month: month,
     p_ip_key: ipHash,
     p_ip_cap: 10,
   });
+  if (error) {
+    // A failed check is a server fault, not a quota hit — don't report 429.
+    return Response.json({ error: "Rate-limit check failed" }, { status: 502 });
+  }
   if (!data?.[0]?.allowed) {
     return Response.json({ error: "OCR quota reached" }, { status: 429 });
   }

--- a/supabase/migrations/20260720130000_drop_ocr_global_overload.sql
+++ b/supabase/migrations/20260720130000_drop_ocr_global_overload.sql
@@ -1,0 +1,20 @@
+-- Drop the 4-argument overload of check_and_increment_ocr.
+--
+-- Two overloads ended up coexisting:
+--   20260426033132_ocr_rate_limit.sql created the global-cap version
+--     check_and_increment_ocr(p_month TEXT, p_ip_key TEXT, p_global_cap INT, p_ip_cap INT)
+--   20260426184331_ocr_rate_limit_drop_global.sql added the per-IP-only version
+--     check_and_increment_ocr(p_month TEXT, p_ip_key TEXT, p_ip_cap INT)
+-- with CREATE OR REPLACE, which does not replace a function of a different
+-- signature — so both remained. (Applying the migrations via the branching
+-- integration re-created the 4-arg one even where it had been dropped by hand.)
+--
+-- The app calls it with three named args (p_month, p_ip_key, p_ip_cap). That
+-- matches the 3-arg version directly AND the 4-arg version, whose p_global_cap
+-- falls to its default — so Postgres rejects the call as ambiguous ("function
+-- ... is not unique"). api.parse-receipt.ts reads only `data` from the RPC, so
+-- the error surfaces as a null result and every scan returns a spurious 429.
+--
+-- Dropping the 4-arg overload leaves a single unambiguous function. Ordered
+-- after both 20260426 migrations so a from-scratch replay ends in this state.
+DROP FUNCTION IF EXISTS check_and_increment_ocr(TEXT, TEXT, INT, INT);


### PR DESCRIPTION
## What

Receipt scanning on the deployed site returns **429 (OCR quota reached)** on every attempt, even for IPs well under the per-IP cap.

- Add `20260720130000_drop_ocr_global_overload.sql` — drops the 4-arg overload of `check_and_increment_ocr`.
- Make `api.parse-receipt.ts` return **502** (not 429) when the rate-limit RPC itself errors.

## Why

Two overloads of `check_and_increment_ocr` coexist in the database:

- `20260426033132_ocr_rate_limit.sql` created the global-cap version: `(p_month TEXT, p_ip_key TEXT, p_global_cap INT, p_ip_cap INT)`
- `20260426184331_ocr_rate_limit_drop_global.sql` added the per-IP-only version `(p_month TEXT, p_ip_key TEXT, p_ip_cap INT)` with `CREATE OR REPLACE`, which does **not** replace a function of a different signature.

The app calls it with three named args (`p_month`, `p_ip_key`, `p_ip_cap`). That matches the 3-arg version directly **and** the 4-arg version (its `p_global_cap` falls to a default), so Postgres rejects the call as ambiguous (`function ... is not unique`). The route read only `data` from the RPC, so that error surfaced as a null result → a spurious 429 on every scan.

Applying the migrations through the branching integration on the PR #24 merge re-created the 4-arg overload even where it had previously been dropped by hand, which is what triggered this now.

## Fixes

1. **Drop the 4-arg overload**, leaving one unambiguous function. The migration is ordered after both `20260426` migrations so a from-scratch replay ends in the same state, and uses `DROP FUNCTION IF EXISTS` so it's idempotent.
2. **Stop swallowing the RPC error.** The route now reads `error` and returns 502 on a failed check, so 429 means only a genuine per-IP quota denial — a dependency failure can no longer masquerade as a quota hit (which is exactly what hid this bug). The client falls back to local OCR on both statuses.

## Notes for the reviewer

- **To unblock production immediately** without waiting on the merge, run the drop directly in the SQL editor — it's idempotent, so the migration re-running it on merge is harmless:
  ```sql
  DROP FUNCTION IF EXISTS check_and_increment_ocr(TEXT, TEXT, INT, INT);
  ```
- `pnpm typecheck` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)