### PR TITLE
Fix shared receipt not displaying, and order it below the summary

### DIFF
--- a/app/splitter/components/SplitterShell.tsx
+++ b/app/splitter/components/SplitterShell.tsx
@@ -377,19 +377,20 @@ export function SplitterShell({
             {!isSharedView && (
               <ReceiptPreview key={receiptVersion} billId={savedBillId} />
             )}
-            {/* A shared receipt streams from the server rather than IndexedDB,
-                shown only when the sharer opted to include it. */}
-            {isSharedView && sharedBill?.hasReceipt && (
-              <ReceiptPreview
-                imageUrl={`/api/bill/${sharedBill.shareCode}/receipt`}
-              />
-            )}
             <BillSummary
               items={items}
               participants={participants}
               tax={tax}
               tip={tip}
             />
+            {/* A shared receipt streams from the server rather than IndexedDB,
+                shown only when the sharer opted to include it. It sits below the
+                summary so the totals lead and the receipt backs them up. */}
+            {isSharedView && sharedBill?.hasReceipt && (
+              <ReceiptPreview
+                imageUrl={`/api/bill/${sharedBill.shareCode}/receipt`}
+              />
+            )}
           </div>
         </div>
       </div>

--- a/app/splitter/hooks/useBillsStore.ts
+++ b/app/splitter/hooks/useBillsStore.ts
@@ -270,6 +270,11 @@ export function useBillsStore() {
           bill: activeBill.bill,
           cachedAt: now,
           expiresAt: now + SHARED_TTL,
+          // Record whether a receipt was actually attached, so the sharer's own
+          // view (which reads this cache before the API) shows the preview. The
+          // clientLoader returns this entry as-is on the immediate redirect, so
+          // an omitted flag would hide the receipt until the cache expired.
+          hasReceipt: !!receipt,
         });
         forgetLocalBill(activeBill.id);
         onSuccess?.(code);


### PR DESCRIPTION
## What

Two fixes to the shared-bill view:

1. The scanned receipt didn't display for the person who had just shared the bill.
2. The receipt rendered above the bill summary, pushing the totals below the fold.

## Why

**Receipt not displaying (`fb5f641`).** After a successful share, `confirmShare` cached the new `SharedBill` in localStorage **without** a `hasReceipt` flag, then redirected to `/splitter/share/:code`. That route's `clientLoader` checks the localStorage cache *first* and returns the entry as-is — so it never reached the API-fetch branch that sets `hasReceipt: true`. `SplitterShell` gates the receipt preview on `sharedBill?.hasReceipt`, so the sharer never saw the receipt they'd just uploaded. A fresh visitor (cache miss → API fetch) saw it fine, which is why it looked intermittent.

Fix: cache `hasReceipt: !!receipt`, matching what the server persists as `receipt_path`.

**Summary order (`f732723`).** In the shared view the receipt was rendered before `BillSummary`. Moved the summary ahead of the receipt so the split leads and the receipt backs it up. The editing view's upload/preview-above-summary order is unchanged.

## Verification

Exercised on the dev server without spending OCR quota or creating production data:

- **Receipt gating (differential network check):** a cached `SharedBill` *with* `hasReceipt` fires `GET /api/bill/:code/receipt` (preview mounts); *without* it, the request never fires (preview hidden) — matching the before/after of the fix.
- **Order:** with the receipt image stubbed so it renders, the shared view lays out People → Items → **Bill Summary** (Subtotal/Total) → **Scanned Receipt**, summary above receipt.
- `pnpm typecheck` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)