### PR TITLE
Lead with the bill summary in the editing view

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,7 @@ build
 .dev.vars*
 !.dev.vars.example
 !.env.example
+
+# Claude Code local config (per-user / machine-specific)
+.claude/settings.local.json
+.claude/launch.json

--- a/app/splitter/components/SplitterShell.tsx
+++ b/app/splitter/components/SplitterShell.tsx
@@ -374,18 +374,18 @@ export function SplitterShell({
                 />
               </div>
             )}
-            {!isSharedView && (
-              <ReceiptPreview key={receiptVersion} billId={savedBillId} />
-            )}
             <BillSummary
               items={items}
               participants={participants}
               tax={tax}
               tip={tip}
             />
-            {/* A shared receipt streams from the server rather than IndexedDB,
-                shown only when the sharer opted to include it. It sits below the
-                summary so the totals lead and the receipt backs them up. */}
+            {/* The scanned receipt sits below the summary in both views so the
+                totals lead and the receipt backs them up — a local draft reads
+                it from IndexedDB, a shared view streams it from the server. */}
+            {!isSharedView && (
+              <ReceiptPreview key={receiptVersion} billId={savedBillId} />
+            )}
             {isSharedView && sharedBill?.hasReceipt && (
               <ReceiptPreview
                 imageUrl={`/api/bill/${sharedBill.shareCode}/receipt`}


### PR DESCRIPTION
## What

- Move the bill summary above the scanned receipt in the **editing** view, matching the shared view.
- Ignore Claude Code local config (`.claude/settings.local.json`, `.claude/launch.json`).

## Why

**Summary order (`53f8ad8`).** The shared view already leads with `BillSummary` and shows the receipt below it. The editing view still rendered the local `ReceiptPreview` above the summary, so the two layouts were inconsistent. Now both lead with the summary and back it up with the receipt — the local draft reads its image from IndexedDB, the shared view streams it from the server. Pure JSX reorder within the same flex column (no CSS `order` in play); `pnpm typecheck` passes.

**Ignore local config (`1d34e50`).** These two files kept showing as untracked. `settings.local.json` is per-user (the `.local` convention), and `launch.json` is a machine-specific preview artifact — neither belongs in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)