### PR TITLE
Set up Vitest and unit-test the splitter logic

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,7 +66,11 @@ pnpm build        # Production build
 pnpm preview      # Build + preview with wrangler
 pnpm deploy       # Build + deploy to Cloudflare Pages
 pnpm typecheck    # Generate route types + run tsc
+pnpm test         # Run the Vitest unit suite once
+pnpm test:watch   # Run Vitest in watch mode
 ```
+
+Unit tests (Vitest, jsdom) live beside the code as `*.test.ts` and cover the pure logic in `app/splitter/utils/` and the section registry. Config is `vitest.config.ts`, kept separate from `vite.config.ts` so tests don't boot the Cloudflare/SSR environment.
 
 `pnpm deploy` (wrangler) deploys to a **preview** URL. Production deployments go through CI/CD triggered by pushing to `main`.
 

--- a/app/portfolio/registry.test.ts
+++ b/app/portfolio/registry.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { getSection } from "~/portfolio/registry";
+
+describe("getSection", () => {
+  it.each(["hero", "experience_list", "project_list"])(
+    "resolves the registered '%s' section to a component",
+    (type) => {
+      expect(getSection(type)).toBeTypeOf("function");
+    },
+  );
+
+  it("returns null for an unknown section type", () => {
+    expect(getSection("does_not_exist")).toBeNull();
+  });
+
+  it("returns null for an empty type string", () => {
+    expect(getSection("")).toBeNull();
+  });
+});

--- a/app/splitter/components/BillSummary.tsx
+++ b/app/splitter/components/BillSummary.tsx
@@ -1,26 +1,13 @@
 import { useState } from "react";
 import { MdExpandMore, MdReceipt } from "react-icons/md";
 import type { Item, Participant } from "~/splitter/types";
-import { itemTotal } from "~/splitter/utils/bill";
+import { computeBreakdowns, type PersonBreakdown } from "~/splitter/utils/bill";
 
 interface BillSummaryProps {
   items: Item[];
   participants: Participant[];
   tax: number;
   tip: number;
-}
-
-interface PersonBreakdown {
-  participant: Participant;
-  itemsTotal: number;
-  taxShare: number;
-  tipShare: number;
-  total: number;
-  myItems: Array<{
-    name: string;
-    amount: number;
-    children: Array<{ name: string; amount: number }>;
-  }>;
 }
 
 function PersonCard({ bd }: { bd: PersonBreakdown }) {
@@ -123,62 +110,12 @@ export function BillSummary({
   tax,
   tip,
 }: BillSummaryProps) {
-  // Compute per-participant subtotals
-  const subtotals: Record<string, number> = {};
-  // Tax and tip are apportioned by what each person actually bought, counting
-  // only positively priced items. Weighting by the net instead breaks once
-  // discounts are involved: a group total at or below zero has no meaningful
-  // proportion, and one person's positive share against a negative group total
-  // inverts, handing them a negative share of the tax.
-  const weights: Record<string, number> = {};
-  let totalSubtotal = 0;
-  let totalWeight = 0;
-
-  for (const item of items) {
-    const price = itemTotal(item);
-    totalSubtotal += price;
-    const assigned = item.splitBetween;
-    if (assigned.length === 0) continue;
-    const share = price / assigned.length;
-    for (const pid of assigned) {
-      subtotals[pid] = (subtotals[pid] ?? 0) + share;
-      if (price > 0) weights[pid] = (weights[pid] ?? 0) + share;
-    }
-    if (price > 0) totalWeight += price;
-  }
-
-  const grandTotal = totalSubtotal + tax + tip;
+  const {
+    breakdowns,
+    subtotal: totalSubtotal,
+    grandTotal,
+  } = computeBreakdowns(items, participants, tax, tip);
   const hasData = items.length > 0 && participants.length > 0;
-
-  const breakdowns: PersonBreakdown[] = participants.map((p) => {
-    const sub = subtotals[p.id] ?? 0;
-    // Falls back to an even split only when nobody has been assigned a charge
-    // yet, which is the one case with nothing to proportion by.
-    const proportion =
-      totalWeight > 0
-        ? (weights[p.id] ?? 0) / totalWeight
-        : 1 / participants.length;
-    const myItems = items
-      .filter((i) => i.splitBetween.includes(p.id))
-      .map((i) => ({
-        name: i.name,
-        amount: itemTotal(i) / i.splitBetween.length,
-        // Shown under the item so a total that doesn't match the receipt line
-        // is explained by what modified it.
-        children: (i.children ?? []).map((c) => ({
-          name: c.name,
-          amount: isNaN(c.price) ? 0 : c.price / i.splitBetween.length,
-        })),
-      }));
-    return {
-      participant: p,
-      itemsTotal: sub,
-      taxShare: tax * proportion,
-      tipShare: tip * proportion,
-      total: sub + tax * proportion + tip * proportion,
-      myItems,
-    };
-  });
 
   return (
     <div className="overflow-hidden rounded-2xl border border-ctp-surface1/50 bg-ctp-surface0/40 shadow-lg">

--- a/app/splitter/utils/bill.test.ts
+++ b/app/splitter/utils/bill.test.ts
@@ -1,0 +1,275 @@
+import { describe, expect, it } from "vitest";
+import {
+  canShareBill,
+  computeBreakdowns,
+  itemTotal,
+} from "~/splitter/utils/bill";
+import type { Bill, Item, Participant } from "~/splitter/types";
+
+function item(overrides: Partial<Item> = {}): Item {
+  return {
+    id: "i1",
+    name: "Burger",
+    price: 10,
+    splitBetween: ["p1"],
+    ...overrides,
+  };
+}
+
+function person(id: string, name = id): Participant {
+  return { id, name, color: {} as never };
+}
+
+function bill(overrides: Partial<Bill> = {}): Bill {
+  return {
+    title: "Dinner",
+    participants: [{ id: "p1", name: "Ana", color: {} as never }],
+    items: [item()],
+    tax: 0,
+    tip: 0,
+    ...overrides,
+  };
+}
+
+describe("itemTotal", () => {
+  it("returns the item's own price when it has no children", () => {
+    expect(itemTotal(item({ price: 12.5 }))).toBe(12.5);
+  });
+
+  it("adds every child's price to the base", () => {
+    const withChildren = item({
+      price: 10,
+      children: [
+        { id: "c1", name: "Extra bacon", price: 2 },
+        { id: "c2", name: "Instant savings", price: -3 },
+      ],
+    });
+    expect(itemTotal(withChildren)).toBe(9);
+  });
+
+  it("treats a blank (NaN) price as zero rather than poisoning the sum", () => {
+    expect(itemTotal(item({ price: NaN }))).toBe(0);
+    expect(
+      itemTotal(
+        item({
+          price: 5,
+          children: [{ id: "c1", name: "mod", price: NaN }],
+        }),
+      ),
+    ).toBe(5);
+  });
+
+  it("keeps zero-price children (a free modification) without changing the total", () => {
+    const withFreeMod = item({
+      price: 8,
+      children: [{ id: "c1", name: "No onions", price: 0 }],
+    });
+    expect(itemTotal(withFreeMod)).toBe(8);
+  });
+
+  it("handles an explicitly empty children array", () => {
+    expect(itemTotal(item({ price: 7, children: [] }))).toBe(7);
+  });
+});
+
+describe("canShareBill", () => {
+  it("accepts a fully specified bill", () => {
+    expect(canShareBill(bill())).toBe(true);
+  });
+
+  it("rejects a bill with a blank or whitespace-only title", () => {
+    expect(canShareBill(bill({ title: "" }))).toBe(false);
+    expect(canShareBill(bill({ title: "   " }))).toBe(false);
+  });
+
+  it("rejects a bill with no participants", () => {
+    expect(canShareBill(bill({ participants: [] }))).toBe(false);
+  });
+
+  it("rejects a bill with no items", () => {
+    expect(canShareBill(bill({ items: [] }))).toBe(false);
+  });
+
+  it("rejects when any item has nobody assigned to split it", () => {
+    expect(
+      canShareBill(
+        bill({
+          items: [item(), item({ id: "i2", splitBetween: [] })],
+        }),
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("computeBreakdowns", () => {
+  const ana = person("p1", "Ana");
+  const ben = person("p2", "Ben");
+
+  function totalFor(bd: ReturnType<typeof computeBreakdowns>, id: string) {
+    return bd.breakdowns.find((b) => b.participant.id === id)!.total;
+  }
+
+  it("gives a single person the whole bill", () => {
+    const result = computeBreakdowns(
+      [item({ price: 10, splitBetween: ["p1"] })],
+      [ana],
+      2,
+      1,
+    );
+    expect(result.subtotal).toBe(10);
+    expect(result.grandTotal).toBe(13);
+    expect(result.breakdowns[0].total).toBe(13);
+  });
+
+  it("splits a shared item evenly between its assignees", () => {
+    const result = computeBreakdowns(
+      [item({ price: 10, splitBetween: ["p1", "p2"] })],
+      [ana, ben],
+      0,
+      0,
+    );
+    expect(totalFor(result, "p1")).toBe(5);
+    expect(totalFor(result, "p2")).toBe(5);
+  });
+
+  it("apportions tax and tip by each person's positive spend", () => {
+    // Ana buys $30, Ben buys $10 → tax/tip split 75/25.
+    const result = computeBreakdowns(
+      [
+        item({ id: "i1", price: 30, splitBetween: ["p1"] }),
+        item({ id: "i2", price: 10, splitBetween: ["p2"] }),
+      ],
+      [ana, ben],
+      8,
+      4,
+    );
+    const a = result.breakdowns.find((b) => b.participant.id === "p1")!;
+    const b = result.breakdowns.find((b) => b.participant.id === "p2")!;
+    expect(a.taxShare).toBeCloseTo(6);
+    expect(a.tipShare).toBeCloseTo(3);
+    expect(a.total).toBeCloseTo(39);
+    expect(b.taxShare).toBeCloseTo(2);
+    expect(b.tipShare).toBeCloseTo(1);
+    expect(b.total).toBeCloseTo(13);
+    // The apportioned tax and tip add back up to the amounts charged.
+    expect(a.taxShare + b.taxShare).toBeCloseTo(8);
+    expect(a.tipShare + b.tipShare).toBeCloseTo(4);
+  });
+
+  it("falls back to an even tax/tip split when no positive charge exists", () => {
+    // Only a discount line, so there is no positive spend to weight by.
+    const result = computeBreakdowns(
+      [item({ price: -10, splitBetween: ["p1", "p2"] })],
+      [ana, ben],
+      6,
+      0,
+    );
+    expect(result.breakdowns[0].taxShare).toBeCloseTo(3);
+    expect(result.breakdowns[1].taxShare).toBeCloseTo(3);
+  });
+
+  it("does not hand a discounted-only buyer a negative tax share", () => {
+    // Ana nets -5 (discount), Ben buys 20. Weighting by net would invert Ana's
+    // share; weighting by positive spend keeps all the tax on Ben.
+    const result = computeBreakdowns(
+      [
+        item({ id: "i1", price: -5, splitBetween: ["p1"] }),
+        item({ id: "i2", price: 20, splitBetween: ["p2"] }),
+      ],
+      [ana, ben],
+      4,
+      0,
+    );
+    const a = result.breakdowns.find((b) => b.participant.id === "p1")!;
+    const b = result.breakdowns.find((b) => b.participant.id === "p2")!;
+    expect(a.taxShare).toBe(0);
+    expect(b.taxShare).toBeCloseTo(4);
+    expect(a.itemsTotal).toBe(-5);
+  });
+
+  it("includes sub-items in both the total and the per-person breakdown", () => {
+    const result = computeBreakdowns(
+      [
+        item({
+          price: 10,
+          splitBetween: ["p1", "p2"],
+          children: [{ id: "c1", name: "Extra bacon", price: 4 }],
+        }),
+      ],
+      [ana, ben],
+      0,
+      0,
+    );
+    expect(result.subtotal).toBe(14);
+    expect(totalFor(result, "p1")).toBe(7);
+    const line = result.breakdowns[0].myItems[0];
+    expect(line.amount).toBe(7); // (10 + 4) / 2
+    expect(line.children).toEqual([{ name: "Extra bacon", amount: 2 }]);
+  });
+
+  it("treats a blank (NaN) sub-item price as zero in the breakdown line", () => {
+    const result = computeBreakdowns(
+      [
+        item({
+          price: 10,
+          splitBetween: ["p1"],
+          children: [{ id: "c1", name: "mod", price: NaN }],
+        }),
+      ],
+      [ana],
+      0,
+      0,
+    );
+    expect(result.breakdowns[0].myItems[0].children).toEqual([
+      { name: "mod", amount: 0 },
+    ]);
+  });
+
+  it("lists only the items a person is assigned to", () => {
+    const result = computeBreakdowns(
+      [
+        item({
+          id: "i1",
+          name: "Shared",
+          price: 10,
+          splitBetween: ["p1", "p2"],
+        }),
+        item({ id: "i2", name: "Ben only", price: 6, splitBetween: ["p2"] }),
+      ],
+      [ana, ben],
+      0,
+      0,
+    );
+    const a = result.breakdowns.find((b) => b.participant.id === "p1")!;
+    const b = result.breakdowns.find((b) => b.participant.id === "p2")!;
+    expect(a.myItems.map((i) => i.name)).toEqual(["Shared"]);
+    expect(b.myItems.map((i) => i.name)).toEqual(["Shared", "Ben only"]);
+  });
+
+  it("counts an unassigned item in the subtotal but charges it to nobody", () => {
+    const result = computeBreakdowns(
+      [
+        item({ id: "i1", price: 10, splitBetween: ["p1"] }),
+        item({ id: "i2", price: 8, splitBetween: [] }),
+      ],
+      [ana, ben],
+      0,
+      0,
+    );
+    expect(result.subtotal).toBe(18);
+    expect(totalFor(result, "p1")).toBe(10);
+    expect(totalFor(result, "p2")).toBe(0);
+  });
+
+  it("returns an empty breakdown list when there are no participants", () => {
+    const result = computeBreakdowns(
+      [item({ price: 10, splitBetween: ["p1"] })],
+      [],
+      1,
+      1,
+    );
+    expect(result.breakdowns).toEqual([]);
+    expect(result.subtotal).toBe(10);
+    expect(result.grandTotal).toBe(12);
+  });
+});

--- a/app/splitter/utils/bill.ts
+++ b/app/splitter/utils/bill.ts
@@ -1,4 +1,4 @@
-import type { Bill, Item } from "~/splitter/types";
+import type { Bill, Item, Participant } from "~/splitter/types";
 
 /**
  * What an item actually costs: its own price plus every sub-item. Sub-items
@@ -23,4 +23,96 @@ export function canShareBill(bill: Bill): boolean {
     bill.items.length > 0 &&
     bill.items.every((i) => i.splitBetween.length > 0)
   );
+}
+
+/** One line under a participant, explaining what makes up their share. */
+export interface BreakdownLine {
+  name: string;
+  amount: number;
+  children: Array<{ name: string; amount: number }>;
+}
+
+/** Everything one participant owes, and why. */
+export interface PersonBreakdown {
+  participant: Participant;
+  itemsTotal: number;
+  taxShare: number;
+  tipShare: number;
+  total: number;
+  myItems: BreakdownLine[];
+}
+
+export interface BillBreakdown {
+  breakdowns: PersonBreakdown[];
+  /** Sum of every item (net of discounts) — the grand total before tax and tip. */
+  subtotal: number;
+  /** subtotal + tax + tip. */
+  grandTotal: number;
+}
+
+/**
+ * Splits a bill into what each participant owes.
+ *
+ * Each item is divided evenly among the people assigned to it. Tax and tip are
+ * then apportioned by what each person actually bought, counting only
+ * positively priced items: weighting by the net breaks once discounts are
+ * involved, since a group total at or below zero has no meaningful proportion,
+ * and one person's positive share against a negative group total inverts,
+ * handing them a negative slice of the tax. When nothing has been assigned a
+ * charge yet — the one case with nothing to proportion by — tax and tip fall
+ * back to an even split across all participants.
+ */
+export function computeBreakdowns(
+  items: Item[],
+  participants: Participant[],
+  tax: number,
+  tip: number,
+): BillBreakdown {
+  const subtotals: Record<string, number> = {};
+  const weights: Record<string, number> = {};
+  let subtotal = 0;
+  let totalWeight = 0;
+
+  for (const item of items) {
+    const price = itemTotal(item);
+    subtotal += price;
+    const assigned = item.splitBetween;
+    if (assigned.length === 0) continue;
+    const share = price / assigned.length;
+    for (const pid of assigned) {
+      subtotals[pid] = (subtotals[pid] ?? 0) + share;
+      if (price > 0) weights[pid] = (weights[pid] ?? 0) + share;
+    }
+    if (price > 0) totalWeight += price;
+  }
+
+  const breakdowns: PersonBreakdown[] = participants.map((p) => {
+    const sub = subtotals[p.id] ?? 0;
+    const proportion =
+      totalWeight > 0
+        ? (weights[p.id] ?? 0) / totalWeight
+        : 1 / participants.length;
+    const myItems: BreakdownLine[] = items
+      .filter((i) => i.splitBetween.includes(p.id))
+      .map((i) => ({
+        name: i.name,
+        amount: itemTotal(i) / i.splitBetween.length,
+        children: (i.children ?? []).map((c) => ({
+          name: c.name,
+          amount: isNaN(c.price) ? 0 : c.price / i.splitBetween.length,
+        })),
+      }));
+    const taxShare = tax * proportion;
+    const tipShare = tip * proportion;
+    return {
+      participant: p,
+      itemsTotal: sub,
+      taxShare,
+      tipShare,
+      total: sub + taxShare + tipShare,
+      myItems,
+    };
+  });
+
+  return { breakdowns, subtotal, grandTotal: subtotal + tax + tip };
 }

--- a/app/splitter/utils/colors.test.ts
+++ b/app/splitter/utils/colors.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { colorForIndex, nextColorSeed } from "~/splitter/utils/colors";
+
+// These tests assert behaviour relative to the palette's length rather than
+// hard-coding class strings, so restyling a colour can't break them.
+const PALETTE_SIZE = 7;
+
+describe("colorForIndex", () => {
+  it("returns a distinct colour for each of the first six indices", () => {
+    const chips = Array.from({ length: PALETTE_SIZE }, (_, i) =>
+      colorForIndex(i),
+    ).map((c) => c.chip);
+    expect(new Set(chips).size).toBe(PALETTE_SIZE);
+  });
+
+  it("wraps around once the palette is exhausted", () => {
+    expect(colorForIndex(PALETTE_SIZE)).toEqual(colorForIndex(0));
+    expect(colorForIndex(PALETTE_SIZE + 1)).toEqual(colorForIndex(1));
+  });
+
+  it("returns a fully-populated colour object", () => {
+    const c = colorForIndex(0);
+    expect(c).toMatchObject({
+      chip: expect.any(String),
+      avatar: expect.any(String),
+      text: expect.any(String),
+      button: expect.any(String),
+    });
+  });
+});
+
+describe("nextColorSeed", () => {
+  it("starts at 0 when there are no participants", () => {
+    expect(nextColorSeed([])).toBe(0);
+  });
+
+  it("starts at 0 when no participant carries a colour", () => {
+    expect(nextColorSeed([{}, {}])).toBe(0);
+  });
+
+  it("returns one past the highest palette index in use", () => {
+    const participants = [
+      { color: colorForIndex(0) },
+      { color: colorForIndex(2) },
+    ];
+    expect(nextColorSeed(participants)).toBe(3);
+  });
+
+  it("ignores participants without a colour when finding the max", () => {
+    const participants = [{ color: colorForIndex(1) }, {}];
+    expect(nextColorSeed(participants)).toBe(2);
+  });
+
+  it("is unaffected by the order participants are listed in", () => {
+    const participants = [
+      { color: colorForIndex(4) },
+      { color: colorForIndex(1) },
+    ];
+    expect(nextColorSeed(participants)).toBe(5);
+  });
+
+  it("ignores a colour whose chip is not in the palette", () => {
+    expect(nextColorSeed([{ color: { chip: "unknown" } as never }])).toBe(0);
+  });
+});

--- a/app/splitter/utils/parseReceiptText.test.ts
+++ b/app/splitter/utils/parseReceiptText.test.ts
@@ -1,0 +1,203 @@
+import { describe, expect, it } from "vitest";
+import { parseReceiptText } from "~/splitter/utils/parseReceiptText";
+
+describe("parseReceiptText — items", () => {
+  it("parses plain 'name  price' lines into items", () => {
+    const result = parseReceiptText("Burger  10.00\nFries  4.50");
+    expect(result.items).toEqual([
+      { description: "Burger", total_amount: 10 },
+      { description: "Fries", total_amount: 4.5 },
+    ]);
+  });
+
+  it("strips a leading dollar sign", () => {
+    expect(parseReceiptText("Latte  $4.25").items).toEqual([
+      { description: "Latte", total_amount: 4.25 },
+    ]);
+  });
+
+  it("reads a leading-minus discount as negative", () => {
+    expect(parseReceiptText("Coupon  -2.00").items).toEqual([
+      { description: "Coupon", total_amount: -2 },
+    ]);
+  });
+
+  it("reads a trailing-minus (Costco-style) discount as negative", () => {
+    expect(parseReceiptText("Instant Rebate  3.00-").items).toEqual([
+      { description: "Instant Rebate", total_amount: -3 },
+    ]);
+  });
+
+  it("ignores lines with no recognisable price", () => {
+    expect(parseReceiptText("Thank you for shopping!\n***").items).toEqual([]);
+  });
+
+  it("requires two decimal places, so a bare integer is not a price", () => {
+    expect(parseReceiptText("Table 12").items).toEqual([]);
+  });
+
+  it("drops absurd amounts of 10000 or more (misread lines)", () => {
+    expect(parseReceiptText("Weird  10000.00").items).toEqual([]);
+    expect(parseReceiptText("Fine  9999.99").items).toEqual([
+      { description: "Fine", total_amount: 9999.99 },
+    ]);
+  });
+
+  it("skips a zero-priced top-level line", () => {
+    expect(parseReceiptText("Freebie  0.00").items).toEqual([]);
+  });
+
+  it("skips single-character descriptions", () => {
+    expect(parseReceiptText("X  5.00").items).toEqual([]);
+  });
+
+  it("ignores blank lines", () => {
+    expect(parseReceiptText("\n\nBurger  10.00\n\n").items).toEqual([
+      { description: "Burger", total_amount: 10 },
+    ]);
+  });
+});
+
+describe("parseReceiptText — skip words", () => {
+  it("drops summary and tender lines using word boundaries", () => {
+    const text = [
+      "Burger  10.00",
+      "SUBTOTAL  10.00",
+      "TOTAL  10.85",
+      "BALANCE DUE  10.85",
+      "VISA  10.85",
+      "CHANGE  0.00",
+    ].join("\n");
+    expect(parseReceiptText(text).items).toEqual([
+      { description: "Burger", total_amount: 10 },
+    ]);
+  });
+
+  it("does not let 'cash'/'change'/'due' match inside real item names", () => {
+    const text = [
+      "CASHEWS  6.00",
+      "EXCHANGE PLATE  8.00",
+      "FONDUE  12.00",
+    ].join("\n");
+    expect(parseReceiptText(text).items).toEqual([
+      { description: "CASHEWS", total_amount: 6 },
+      { description: "EXCHANGE PLATE", total_amount: 8 },
+      { description: "FONDUE", total_amount: 12 },
+    ]);
+  });
+});
+
+describe("parseReceiptText — savings tally", () => {
+  it("drops a positive savings-total line that restates discounts", () => {
+    const text = "Item  13.99\nINSTANT SAVINGS  6.50";
+    expect(parseReceiptText(text).items).toEqual([
+      { description: "Item", total_amount: 13.99 },
+    ]);
+  });
+
+  it("keeps a genuine negative savings line as a discount", () => {
+    const text = "Item  13.99\nInstant Savings  -6.50";
+    expect(parseReceiptText(text).items).toEqual([
+      { description: "Item", total_amount: 13.99 },
+      { description: "Instant Savings", total_amount: -6.5 },
+    ]);
+  });
+});
+
+describe("parseReceiptText — tax", () => {
+  it("extracts a single tax line", () => {
+    const result = parseReceiptText("Burger  10.00\nTAX  0.85");
+    expect(result.tax).toBe(0.85);
+    expect(result.taxLineCount).toBe(1);
+  });
+
+  it("sums split state and city tax and counts both lines", () => {
+    const result = parseReceiptText(
+      "Burger  10.00\nSTATE TAX  0.50\nCITY TAX  0.35",
+    );
+    expect(result.tax).toBeCloseTo(0.85);
+    expect(result.taxLineCount).toBe(2);
+  });
+
+  it("prefers the charged tax over a 'TOTAL TAX' restatement of the same money", () => {
+    const result = parseReceiptText(
+      "Burger  10.00\nTAX  0.85\nTOTAL TAX  0.85",
+    );
+    expect(result.tax).toBe(0.85);
+    expect(result.taxLineCount).toBe(1);
+  });
+
+  it("falls back to the restatement when it is the only tax line", () => {
+    const result = parseReceiptText("Burger  10.00\nTOTAL TAX  0.85");
+    expect(result.tax).toBe(0.85);
+    expect(result.taxLineCount).toBe(1);
+  });
+
+  it("reports no tax when none is present", () => {
+    const result = parseReceiptText("Burger  10.00");
+    expect(result.tax).toBeUndefined();
+    expect(result.taxLineCount).toBe(0);
+  });
+
+  it("does not treat a negative 'tax'-labelled line as tax", () => {
+    // amount must be > 0 to count as tax; otherwise it is an ordinary line.
+    const result = parseReceiptText("Tax Refund  -1.00");
+    expect(result.tax).toBeUndefined();
+    expect(result.items).toEqual([
+      { description: "Tax Refund", total_amount: -1 },
+    ]);
+  });
+});
+
+describe("parseReceiptText — tip", () => {
+  it("extracts a tip line", () => {
+    expect(parseReceiptText("Meal  20.00\nTIP  4.00").tip).toBe(4);
+  });
+
+  it("recognises gratuity as tip", () => {
+    expect(parseReceiptText("Meal  20.00\nGratuity  3.60").tip).toBe(3.6);
+  });
+
+  it("reports no tip when none is present", () => {
+    expect(parseReceiptText("Meal  20.00").tip).toBeUndefined();
+  });
+});
+
+describe("parseReceiptText — children (indented adjustments)", () => {
+  it("attaches an indented line to the item above it", () => {
+    const text = "Burger  10.00\n  Extra bacon  2.00";
+    expect(parseReceiptText(text).items).toEqual([
+      {
+        description: "Burger",
+        total_amount: 10,
+        children: [{ description: "Extra bacon", total_amount: 2 }],
+      },
+    ]);
+  });
+
+  it("keeps a zero-price indented modification as a child", () => {
+    const text = "Burger  10.00\n  No onions  0.00";
+    expect(parseReceiptText(text).items).toEqual([
+      {
+        description: "Burger",
+        total_amount: 10,
+        children: [{ description: "No onions", total_amount: 0 }],
+      },
+    ]);
+  });
+
+  it("attaches multiple children to the same parent", () => {
+    const text = "Burger  10.00\n  Extra bacon  2.00\n  Discount  -1.00";
+    expect(parseReceiptText(text).items[0].children).toEqual([
+      { description: "Extra bacon", total_amount: 2 },
+      { description: "Discount", total_amount: -1 },
+    ]);
+  });
+
+  it("promotes an indented line to a top-level item when nothing precedes it", () => {
+    // No parent exists yet, so it cannot be a child; it stands on its own.
+    expect(parseReceiptText("  Orphan  5.00").items).toEqual([
+      { description: "Orphan", total_amount: 5 },
+    ]);
+  });
+});

--- a/app/splitter/utils/receiptSchema.test.ts
+++ b/app/splitter/utils/receiptSchema.test.ts
@@ -1,0 +1,226 @@
+import { describe, expect, it } from "vitest";
+import { fromSchema, recoverJson } from "~/splitter/utils/receiptSchema";
+
+describe("recoverJson", () => {
+  it("returns a clean object unchanged", () => {
+    const json = '{"a":1}';
+    expect(recoverJson(json)).toBe('{"a":1}');
+  });
+
+  it("strips a leading sentence and a trailing ```json fence", () => {
+    const reply = 'Here is the receipt: ```json\n{"a":1}\n``` done';
+    expect(recoverJson(reply)).toBe('{"a":1}');
+  });
+
+  it("stops at the first complete top-level object, ignoring trailing prose", () => {
+    expect(recoverJson('{"a":1} and then some notes')).toBe('{"a":1}');
+  });
+
+  it("returns null when there is no object at all", () => {
+    expect(recoverJson("no json here")).toBeNull();
+  });
+
+  it("ignores braces that appear inside strings", () => {
+    const json = '{"name":"a } b [ c"}';
+    expect(recoverJson(json)).toBe(json);
+  });
+
+  it("respects escaped quotes inside strings", () => {
+    const json = '{"name":"say \\"hi\\""}';
+    expect(recoverJson(json)).toBe(json);
+  });
+
+  it("closes an object truncated mid-generation back to the last clean value", () => {
+    // Cut off right after an item object closed but before the array/object did.
+    const truncated = '{"items":[{"name":"A","price":1.00}';
+    const recovered = recoverJson(truncated);
+    expect(recovered).toBe('{"items":[{"name":"A","price":1.00}]}');
+    expect(() => JSON.parse(recovered!)).not.toThrow();
+  });
+
+  it("returns null when nothing completed before the cut", () => {
+    expect(recoverJson('{"items":[{"name":"A"')).toBeNull();
+  });
+});
+
+describe("fromSchema", () => {
+  it("reads items, per-item adjustments, order discounts, tax and tip", () => {
+    const reply = JSON.stringify({
+      items: [
+        {
+          name: "KS FRZ GAL",
+          price: 13.99,
+          adjustments: [{ name: "Instant savings", price: -3.0 }],
+        },
+        { name: "BEEF ROLLS", price: 14.99, adjustments: [] },
+      ],
+      orderDiscounts: [{ name: "Member savings", price: -6.5 }],
+      taxes: [{ name: "TAX", amount: 7.17 }],
+      tip: 0,
+    });
+
+    const result = fromSchema(reply)!;
+    expect(result.items).toEqual([
+      {
+        description: "KS FRZ GAL",
+        total_amount: 13.99,
+        children: [{ description: "Instant savings", total_amount: -3 }],
+      },
+      { description: "BEEF ROLLS", total_amount: 14.99 },
+      { description: "Member savings", total_amount: -6.5 },
+    ]);
+    expect(result.tax).toBe(7.17);
+    expect(result.taxLineCount).toBe(1);
+    expect(result.tip).toBeUndefined();
+  });
+
+  it("reads a tax amount the model emitted under 'price' instead of 'amount'", () => {
+    const reply = JSON.stringify({
+      items: [{ name: "A", price: 1, adjustments: [] }],
+      taxes: [{ name: "TAX", price: 0.85 }],
+      tip: 0,
+    });
+    expect(fromSchema(reply)!.tax).toBe(0.85);
+  });
+
+  it("coerces string numbers and rejects non-numeric ones", () => {
+    const reply = JSON.stringify({
+      items: [
+        { name: "A", price: "12.50", adjustments: [] },
+        { name: "B", price: "abc", adjustments: [] },
+      ],
+      tip: 0,
+    });
+    expect(fromSchema(reply)!.items).toEqual([
+      { description: "A", total_amount: 12.5 },
+    ]);
+  });
+
+  it("sums multiple tax lines and counts them", () => {
+    const reply = JSON.stringify({
+      items: [{ name: "A", price: 1, adjustments: [] }],
+      taxes: [
+        { name: "STATE", amount: 0.5 },
+        { name: "CITY", amount: 0.35 },
+      ],
+      tip: 0,
+    });
+    const result = fromSchema(reply)!;
+    expect(result.tax).toBeCloseTo(0.85);
+    expect(result.taxLineCount).toBe(2);
+  });
+
+  it("drops non-positive tax lines", () => {
+    const reply = JSON.stringify({
+      items: [{ name: "A", price: 1, adjustments: [] }],
+      taxes: [
+        { name: "TAX", amount: 0 },
+        { name: "REFUND", amount: -1 },
+      ],
+      tip: 0,
+    });
+    const result = fromSchema(reply)!;
+    expect(result.tax).toBeUndefined();
+    expect(result.taxLineCount).toBe(0);
+  });
+
+  it("keeps a zero-priced item adjustment (a free modification)", () => {
+    const reply = JSON.stringify({
+      items: [
+        {
+          name: "Burger",
+          price: 10,
+          adjustments: [{ name: "No onions", price: 0 }],
+        },
+      ],
+      tip: 0,
+    });
+    expect(fromSchema(reply)!.items[0].children).toEqual([
+      { description: "No onions", total_amount: 0 },
+    ]);
+  });
+
+  it("drops zero-amount order-level discounts", () => {
+    const reply = JSON.stringify({
+      items: [{ name: "A", price: 1, adjustments: [] }],
+      orderDiscounts: [{ name: "Nothing", price: 0 }],
+      tip: 0,
+    });
+    expect(fromSchema(reply)!.items).toEqual([
+      { description: "A", total_amount: 1 },
+    ]);
+  });
+
+  it("also reads order discounts the model placed under a flat 'adjustments' key", () => {
+    const reply = JSON.stringify({
+      items: [{ name: "A", price: 1, adjustments: [] }],
+      adjustments: [{ name: "Member savings", price: -6.5 }],
+      tip: 0,
+    });
+    expect(fromSchema(reply)!.items).toContainEqual({
+      description: "Member savings",
+      total_amount: -6.5,
+    });
+  });
+
+  it("reports a positive tip and omits a zero one", () => {
+    const withTip = JSON.stringify({
+      items: [{ name: "A", price: 1, adjustments: [] }],
+      tip: 5,
+    });
+    expect(fromSchema(withTip)!.tip).toBe(5);
+  });
+
+  it("rejects an amount of 10000 or more as a misread", () => {
+    const reply = JSON.stringify({
+      items: [
+        { name: "Sane", price: 12, adjustments: [] },
+        { name: "Bogus", price: 10000, adjustments: [] },
+      ],
+      tip: 0,
+    });
+    expect(fromSchema(reply)!.items).toEqual([
+      { description: "Sane", total_amount: 12 },
+    ]);
+  });
+
+  it("skips items missing a name or price", () => {
+    const reply = JSON.stringify({
+      items: [
+        { name: "", price: 5, adjustments: [] },
+        { name: "  ", price: 5, adjustments: [] },
+        { price: 5, adjustments: [] },
+        { name: "Good", price: 5, adjustments: [] },
+      ],
+      tip: 0,
+    });
+    expect(fromSchema(reply)!.items).toEqual([
+      { description: "Good", total_amount: 5 },
+    ]);
+  });
+
+  it("returns null when the reply has no JSON object", () => {
+    expect(fromSchema("sorry, I can't read this")).toBeNull();
+  });
+
+  it("returns null when the JSON is malformed beyond recovery", () => {
+    expect(fromSchema("{ not: valid, json }")).toBeNull();
+  });
+
+  it("returns null when 'items' is missing or not an array", () => {
+    expect(fromSchema(JSON.stringify({ tip: 0 }))).toBeNull();
+    expect(fromSchema(JSON.stringify({ items: "nope", tip: 0 }))).toBeNull();
+  });
+
+  it("recovers items from a reply truncated mid-generation", () => {
+    const truncated =
+      '{"items":[{"name":"A","price":1.00,"adjustments":[]},' +
+      '{"name":"B","price":2.00,"adjustments":[]}';
+    const result = fromSchema(truncated)!;
+    expect(result).not.toBeNull();
+    expect(result.items).toEqual([
+      { description: "A", total_amount: 1 },
+      { description: "B", total_amount: 2 },
+    ]);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "deploy": "pnpm run build && wrangler deploy",
     "prepare": "husky",
     "lint": "eslint app/",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "cf-typegen": "wrangler types"
@@ -54,12 +56,14 @@
     "eslint-plugin-react-hooks": "^7",
     "husky": "^9.1.7",
     "isbot": "^5.1.36",
+    "jsdom": "^29.1.1",
     "lint-staged": "^16.4.0",
     "prettier": "^3.8.1",
     "tailwindcss": "^4.2.2",
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.58.0",
     "vite": "^8.0.5",
+    "vitest": "^4.1.10",
     "wrangler": "^4.80.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,6 +87,9 @@ importers:
       isbot:
         specifier: ^5.1.36
         version: 5.1.37
+      jsdom:
+        specifier: ^29.1.1
+        version: 29.1.1
       lint-staged:
         specifier: ^16.4.0
         version: 16.4.0
@@ -105,11 +108,29 @@ importers:
       vite:
         specifier: ^8.0.5
         version: 8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3)
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@types/node@25.5.2)(jsdom@29.1.1)(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3))
       wrangler:
         specifier: ^4.80.0
         version: 4.80.0(@cloudflare/workers-types@4.20260403.1)
 
 packages:
+
+  '@asamuzakjp/css-color@5.1.11':
+    resolution: {integrity: sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/dom-selector@7.1.1':
+    resolution: {integrity: sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/generational-cache@1.0.1':
+    resolution: {integrity: sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/nwsapi@2.3.9':
+    resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -240,6 +261,10 @@ packages:
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
 
+  '@bramus/specificity@2.4.2':
+    resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
+    hasBin: true
+
   '@catppuccin/palette@1.8.0':
     resolution: {integrity: sha512-qXhwKiLzQomUygUJYB36YAFgs+dET5bIocfkiaFIatQF5Pwc7L112TlF9P8J5Oqs3x3XTjYSucG0ncHXSCuk7Q==}
 
@@ -305,6 +330,42 @@ packages:
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
     engines: {node: '>=12'}
+
+  '@csstools/color-helpers@6.1.0':
+    resolution: {integrity: sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==}
+    engines: {node: '>=20.19.0'}
+
+  '@csstools/css-calc@3.2.1':
+    resolution: {integrity: sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-color-parser@4.1.9':
+    resolution: {integrity: sha512-paQcIaOO53Rk5+YrBaBjm/SgrV4INImjo2BT1DtQRYr+XeTRbeAYlS+jxXp9drqvKmtFnWRJKIalDLhZZDu42A==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0':
+    resolution: {integrity: sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.6':
+    resolution: {integrity: sha512-TcJCWFbXLPpJYq6z7bfOyjWYJDiDg2/I4gyUC9pqPNqHFRIey0EB0q0L5cSnQDfWJg8Jd6VadakxdIez/3zkqQ==}
+    peerDependencies:
+      css-tree: ^3.2.1
+    peerDependenciesMeta:
+      css-tree:
+        optional: true
+
+  '@csstools/css-tokenizer@4.0.0':
+    resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
+    engines: {node: '>=20.19.0'}
 
   '@emnapi/core@1.9.2':
     resolution: {integrity: sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==}
@@ -664,6 +725,15 @@ packages:
   '@eslint/plugin-kit@0.4.1':
     resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@exodus/bytes@1.15.1':
+    resolution: {integrity: sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      '@noble/hashes': ^1.8.0 || ^2.0.0
+    peerDependenciesMeta:
+      '@noble/hashes':
+        optional: true
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -1240,6 +1310,9 @@ packages:
   '@speed-highlight/core@1.2.15':
     resolution: {integrity: sha512-BMq1K3DsElxDWawkX6eLg9+CKJrTVGCBAWVuHXVUV2u0s2711qiChLSId6ikYPfxhdYocLNt3wWwSvDiTvFabw==}
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
   '@supabase/auth-js@2.101.1':
     resolution: {integrity: sha512-Kd0Wey+RkFHgyVep7adS6UOE2pN6MJ3mZ32PAXSvfw6IjUkFRC7IQpdZZjUOcUe5pXr1ejufCRgF6lsGINe4Tw==}
     engines: {node: '>=20.0.0'}
@@ -1364,8 +1437,14 @@ packages:
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
   '@types/debug@4.1.13':
     resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/estree-jsx@1.0.5':
     resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
@@ -1467,6 +1546,35 @@ packages:
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
 
+  '@vitest/expect@4.1.10':
+    resolution: {integrity: sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==}
+
+  '@vitest/mocker@4.1.10':
+    resolution: {integrity: sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.10':
+    resolution: {integrity: sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==}
+
+  '@vitest/runner@4.1.10':
+    resolution: {integrity: sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==}
+
+  '@vitest/snapshot@4.1.10':
+    resolution: {integrity: sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==}
+
+  '@vitest/spy@4.1.10':
+    resolution: {integrity: sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==}
+
+  '@vitest/utils@4.1.10':
+    resolution: {integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -1502,6 +1610,10 @@ packages:
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   babel-dead-code-elimination@1.0.12:
     resolution: {integrity: sha512-GERT7L2TiYcYDtYk1IpD+ASAYXjKbLTDPhBtYj7X1NuRMDTMtAx9kyBenub1Ev41lo91OHCKdmP+egTDmfQ7Ig==}
 
@@ -1519,6 +1631,9 @@ packages:
     resolution: {integrity: sha512-fOVLPAsFTsQfuCkvahZkzq6nf8KvGWanlYoTh0SVA0A/PIUxQGU2AOZAoD95n2gFLVDW/jP6sbGLny95nmEuHA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
+
+  bidi-js@1.0.3:
+    resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
   blake3-wasm@2.1.5:
     resolution: {integrity: sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==}
@@ -1551,6 +1666,10 @@ packages:
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
@@ -1618,8 +1737,16 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
+  css-tree@3.2.1:
+    resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  data-urls@7.0.0:
+    resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -1629,6 +1756,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
   decode-named-character-reference@1.3.0:
     resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
@@ -1665,6 +1795,10 @@ packages:
     resolution: {integrity: sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==}
     engines: {node: '>=10.13.0'}
 
+  entities@8.0.0:
+    resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
+    engines: {node: '>=20.19.0'}
+
   environment@1.1.0:
     resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
     engines: {node: '>=18'}
@@ -1674,6 +1808,9 @@ packages:
 
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  es-module-lexer@2.3.1:
+    resolution: {integrity: sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==}
 
   esbuild@0.27.3:
     resolution: {integrity: sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==}
@@ -1750,6 +1887,9 @@ packages:
   estree-util-is-identifier-name@3.0.0:
     resolution: {integrity: sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
@@ -1760,6 +1900,10 @@ packages:
   exit-hook@2.2.1:
     resolution: {integrity: sha512-eNTPlAD67BmP31LDINZ3U7HSF8l57TxOY2PmBJ1shpCvpnxBF93mWCE8YHBnXs8qiUZJc9WDcWIeC3a2HIAMfw==}
     engines: {node: '>=6'}
+
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
 
   exsolve@1.0.8:
     resolution: {integrity: sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==}
@@ -1840,6 +1984,10 @@ packages:
   hermes-parser@0.25.1:
     resolution: {integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==}
 
+  html-encoding-sniffer@6.0.0:
+    resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
   html-url-attributes@3.0.1:
     resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
 
@@ -1902,6 +2050,9 @@ packages:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
 
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
   is-url@1.2.4:
     resolution: {integrity: sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==}
 
@@ -1922,6 +2073,15 @@ packages:
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
+
+  jsdom@29.1.1:
+    resolution: {integrity: sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24.0.0}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   jsesc@3.0.2:
     resolution: {integrity: sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==}
@@ -2058,6 +2218,10 @@ packages:
     engines: {node: '>= 8.x', npm: '>= 5.x'}
     hasBin: true
 
+  lru-cache@11.5.2:
+    resolution: {integrity: sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==}
+    engines: {node: 20 || >=22}
+
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
@@ -2087,6 +2251,9 @@ packages:
 
   mdast-util-to-string@4.0.0:
     resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
+
+  mdn-data@2.27.1:
+    resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
 
   micromark-core-commonmark@2.0.3:
     resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
@@ -2190,6 +2357,10 @@ packages:
   node-releases@2.0.37:
     resolution: {integrity: sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==}
 
+  obug@2.1.4:
+    resolution: {integrity: sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==}
+    engines: {node: '>=12.20.0'}
+
   onetime@7.0.0:
     resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
     engines: {node: '>=18'}
@@ -2220,6 +2391,9 @@ packages:
 
   parse-entities@4.0.2:
     resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
+
+  parse5@8.0.1:
+    resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
 
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
@@ -2319,6 +2493,10 @@ packages:
   remark-rehype@11.1.2:
     resolution: {integrity: sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==}
 
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
@@ -2339,6 +2517,10 @@ packages:
     resolution: {integrity: sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
@@ -2367,6 +2549,9 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
@@ -2385,6 +2570,12 @@ packages:
 
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@4.2.0:
+    resolution: {integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==}
 
   string-argv@0.3.2:
     resolution: {integrity: sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==}
@@ -2423,6 +2614,9 @@ packages:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
 
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
   tailwindcss@4.2.2:
     resolution: {integrity: sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==}
 
@@ -2436,6 +2630,9 @@ packages:
   tesseract.js@7.0.0:
     resolution: {integrity: sha512-exPBkd+z+wM1BuMkx/Bjv43OeLBxhL5kKWsz/9JY+DXcXdiBjiAch0V49QR3oAJqCaL5qURE0vx9Eo+G5YE7mA==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
   tinyexec@1.0.4:
     resolution: {integrity: sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==}
     engines: {node: '>=18'}
@@ -2448,8 +2645,27 @@ packages:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
 
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
+
+  tldts-core@7.4.9:
+    resolution: {integrity: sha512-DxKfPBI52p2msTEu7MPhdpdDTBhhVQg1a/8PjQckeyAvO13eMYElX545grIp6nnTGIMZlRvFZPvFhvI/WIz2Vg==}
+
+  tldts@7.4.9:
+    resolution: {integrity: sha512-3kZ8wQQ/k5DrChD4X4FVvr2D7E5uoRgAqkPyLpSCGUvqOvqu+JEdr3mwMUaVWb+vMHZaKhF5fp2PBigKsui7hA==}
+    hasBin: true
+
+  tough-cookie@6.0.2:
+    resolution: {integrity: sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==}
+    engines: {node: '>=16'}
+
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
+  tr46@6.0.0:
+    resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
+    engines: {node: '>=20'}
 
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
@@ -2487,6 +2703,10 @@ packages:
 
   undici@7.24.4:
     resolution: {integrity: sha512-BM/JzwwaRXxrLdElV2Uo6cTLEjhSb3WXboncJamZ15NgUURmvlXvxa6xkwIOILIjPNo9i8ku136ZvWV0Uly8+w==}
+    engines: {node: '>=20.18.1'}
+
+  undici@7.28.0:
+    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
     engines: {node: '>=20.18.1'}
 
   unenv@2.0.0-rc.24:
@@ -2621,11 +2841,68 @@ packages:
       yaml:
         optional: true
 
+  vitest@4.1.10:
+    resolution: {integrity: sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.10
+      '@vitest/browser-preview': 4.1.10
+      '@vitest/browser-webdriverio': 4.1.10
+      '@vitest/coverage-istanbul': 4.1.10
+      '@vitest/coverage-v8': 4.1.10
+      '@vitest/ui': 4.1.10
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
   wasm-feature-detect@1.8.0:
     resolution: {integrity: sha512-zksaLKM2fVlnB5jQQDqKXXwYHLQUVH9es+5TOOHwGOVJOCeRBCiPjwSg+3tN2AdTCzjgli4jijCH290kXb/zWQ==}
 
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
+  webidl-conversions@8.0.1:
+    resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
+    engines: {node: '>=20'}
+
+  whatwg-mimetype@5.0.0:
+    resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
+    engines: {node: '>=20'}
+
+  whatwg-url@16.0.1:
+    resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
@@ -2633,6 +2910,11 @@ packages:
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   word-wrap@1.2.5:
@@ -2682,6 +2964,13 @@ packages:
       utf-8-validate:
         optional: true
 
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
+
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
@@ -2716,6 +3005,26 @@ packages:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
+
+  '@asamuzakjp/css-color@5.1.11':
+    dependencies:
+      '@asamuzakjp/generational-cache': 1.0.1
+      '@csstools/css-calc': 3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-color-parser': 4.1.9(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@asamuzakjp/dom-selector@7.1.1':
+    dependencies:
+      '@asamuzakjp/generational-cache': 1.0.1
+      '@asamuzakjp/nwsapi': 2.3.9
+      bidi-js: 1.0.3
+      css-tree: 3.2.1
+      is-potential-custom-element-name: 1.0.1
+
+  '@asamuzakjp/generational-cache@1.0.1': {}
+
+  '@asamuzakjp/nwsapi@2.3.9': {}
 
   '@babel/code-frame@7.29.0':
     dependencies:
@@ -2903,6 +3212,10 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
+  '@bramus/specificity@2.4.2':
+    dependencies:
+      css-tree: 3.2.1
+
   '@catppuccin/palette@1.8.0': {}
 
   '@catppuccin/tailwindcss@1.0.0': {}
@@ -2950,6 +3263,30 @@ snapshots:
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
+
+  '@csstools/color-helpers@6.1.0': {}
+
+  '@csstools/css-calc@3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-color-parser@4.1.9(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/color-helpers': 6.1.0
+      '@csstools/css-calc': 3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.6(css-tree@3.2.1)':
+    optionalDependencies:
+      css-tree: 3.2.1
+
+  '@csstools/css-tokenizer@4.0.0': {}
 
   '@emnapi/core@1.9.2':
     dependencies:
@@ -3168,6 +3505,8 @@ snapshots:
     dependencies:
       '@eslint/core': 0.17.0
       levn: 0.4.1
+
+  '@exodus/bytes@1.15.1': {}
 
   '@humanfs/core@0.19.1': {}
 
@@ -3568,6 +3907,8 @@ snapshots:
 
   '@speed-highlight/core@1.2.15': {}
 
+  '@standard-schema/spec@1.1.0': {}
+
   '@supabase/auth-js@2.101.1':
     dependencies:
       tslib: 2.8.1
@@ -3681,9 +4022,16 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
   '@types/debug@4.1.13':
     dependencies:
       '@types/ms': 2.1.0
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/estree-jsx@1.0.5':
     dependencies:
@@ -3816,6 +4164,47 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
+  '@vitest/expect@4.1.10':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.10(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3))':
+    dependencies:
+      '@vitest/spy': 4.1.10
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3)
+
+  '@vitest/pretty-format@4.1.10':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.10':
+    dependencies:
+      '@vitest/utils': 4.1.10
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/utils': 4.1.10
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.10': {}
+
+  '@vitest/utils@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
       acorn: 8.16.0
@@ -3845,6 +4234,8 @@ snapshots:
 
   argparse@2.0.1: {}
 
+  assertion-error@2.0.1: {}
+
   babel-dead-code-elimination@1.0.12:
     dependencies:
       '@babel/core': 7.29.0
@@ -3861,6 +4252,10 @@ snapshots:
   balanced-match@4.0.4: {}
 
   baseline-browser-mapping@2.10.14: {}
+
+  bidi-js@1.0.3:
+    dependencies:
+      require-from-string: 2.0.2
 
   blake3-wasm@2.1.5: {}
 
@@ -3890,6 +4285,8 @@ snapshots:
   caniuse-lite@1.0.30001784: {}
 
   ccount@2.0.1: {}
+
+  chai@6.2.2: {}
 
   chalk@4.1.2:
     dependencies:
@@ -3945,11 +4342,25 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  css-tree@3.2.1:
+    dependencies:
+      mdn-data: 2.27.1
+      source-map-js: 1.2.1
+
   csstype@3.2.3: {}
+
+  data-urls@7.0.0:
+    dependencies:
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  decimal.js@10.6.0: {}
 
   decode-named-character-reference@1.3.0:
     dependencies:
@@ -3976,11 +4387,15 @@ snapshots:
       graceful-fs: 4.2.11
       tapable: 2.3.2
 
+  entities@8.0.0: {}
+
   environment@1.1.0: {}
 
   error-stack-parser-es@1.0.5: {}
 
   es-module-lexer@1.7.0: {}
+
+  es-module-lexer@2.3.1: {}
 
   esbuild@0.27.3:
     optionalDependencies:
@@ -4129,11 +4544,17 @@ snapshots:
 
   estree-util-is-identifier-name@3.0.0: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
   esutils@2.0.3: {}
 
   eventemitter3@5.0.4: {}
 
   exit-hook@2.2.1: {}
+
+  expect-type@1.4.0: {}
 
   exsolve@1.0.8: {}
 
@@ -4212,6 +4633,12 @@ snapshots:
     dependencies:
       hermes-estree: 0.25.1
 
+  html-encoding-sniffer@6.0.0:
+    dependencies:
+      '@exodus/bytes': 1.15.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   html-url-attributes@3.0.1: {}
 
   husky@9.1.7: {}
@@ -4256,6 +4683,8 @@ snapshots:
 
   is-plain-obj@4.1.0: {}
 
+  is-potential-custom-element-name@1.0.1: {}
+
   is-url@1.2.4: {}
 
   isbot@5.1.37: {}
@@ -4269,6 +4698,32 @@ snapshots:
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
+
+  jsdom@29.1.1:
+    dependencies:
+      '@asamuzakjp/css-color': 5.1.11
+      '@asamuzakjp/dom-selector': 7.1.1
+      '@bramus/specificity': 2.4.2
+      '@csstools/css-syntax-patches-for-csstree': 1.1.6(css-tree@3.2.1)
+      '@exodus/bytes': 1.15.1
+      css-tree: 3.2.1
+      data-urls: 7.0.0
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 6.0.0
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.5.2
+      parse5: 8.0.1
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 6.0.2
+      undici: 7.28.0
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 8.0.1
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   jsesc@3.0.2: {}
 
@@ -4380,6 +4835,8 @@ snapshots:
     dependencies:
       commander: 9.5.0
 
+  lru-cache@11.5.2: {}
+
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
@@ -4476,6 +4933,8 @@ snapshots:
   mdast-util-to-string@4.0.0:
     dependencies:
       '@types/mdast': 4.0.4
+
+  mdn-data@2.27.1: {}
 
   micromark-core-commonmark@2.0.3:
     dependencies:
@@ -4644,6 +5103,8 @@ snapshots:
 
   node-releases@2.0.37: {}
 
+  obug@2.1.4: {}
+
   onetime@7.0.0:
     dependencies:
       mimic-function: 5.0.1
@@ -4682,6 +5143,10 @@ snapshots:
       is-alphanumerical: 2.0.1
       is-decimal: 2.0.1
       is-hexadecimal: 2.0.1
+
+  parse5@8.0.1:
+    dependencies:
+      entities: 8.0.0
 
   path-exists@4.0.0: {}
 
@@ -4781,6 +5246,8 @@ snapshots:
       unified: 11.0.5
       vfile: 6.0.3
 
+  require-from-string@2.0.2: {}
+
   resolve-from@4.0.0: {}
 
   restore-cursor@5.1.0:
@@ -4845,6 +5312,10 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.60.1
       fsevents: 2.3.3
 
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
+
   scheduler@0.27.0: {}
 
   semver@6.3.1: {}
@@ -4890,6 +5361,8 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
+  siginfo@2.0.0: {}
+
   signal-exit@4.1.0: {}
 
   slice-ansi@7.1.2:
@@ -4905,6 +5378,10 @@ snapshots:
   source-map-js@1.2.1: {}
 
   space-separated-tokens@2.0.2: {}
+
+  stackback@0.0.2: {}
+
+  std-env@4.2.0: {}
 
   string-argv@0.3.2: {}
 
@@ -4944,6 +5421,8 @@ snapshots:
     dependencies:
       has-flag: 4.0.0
 
+  symbol-tree@3.2.4: {}
+
   tailwindcss@4.2.2: {}
 
   tapable@2.3.2: {}
@@ -4964,6 +5443,8 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
+  tinybench@2.9.0: {}
+
   tinyexec@1.0.4: {}
 
   tinyglobby@0.2.15:
@@ -4976,7 +5457,23 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
 
+  tinyrainbow@3.1.0: {}
+
+  tldts-core@7.4.9: {}
+
+  tldts@7.4.9:
+    dependencies:
+      tldts-core: 7.4.9
+
+  tough-cookie@6.0.2:
+    dependencies:
+      tldts: 7.4.9
+
   tr46@0.0.3: {}
+
+  tr46@6.0.0:
+    dependencies:
+      punycode: 2.3.1
 
   trim-lines@3.0.1: {}
 
@@ -5008,6 +5505,8 @@ snapshots:
   undici-types@7.18.2: {}
 
   undici@7.24.4: {}
+
+  undici@7.28.0: {}
 
   unenv@2.0.0-rc.24:
     dependencies:
@@ -5123,9 +5622,53 @@ snapshots:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
+  vitest@4.1.10(@types/node@25.5.2)(jsdom@29.1.1)(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3)):
+    dependencies:
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3))
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      es-module-lexer: 2.3.1
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.4
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.2.0
+      tinybench: 2.9.0
+      tinyexec: 1.0.4
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
+      vite: 8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 25.5.2
+      jsdom: 29.1.1
+    transitivePeerDependencies:
+      - msw
+
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
   wasm-feature-detect@1.8.0: {}
 
   webidl-conversions@3.0.1: {}
+
+  webidl-conversions@8.0.1: {}
+
+  whatwg-mimetype@5.0.0: {}
+
+  whatwg-url@16.0.1:
+    dependencies:
+      '@exodus/bytes': 1.15.1
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   whatwg-url@5.0.0:
     dependencies:
@@ -5135,6 +5678,11 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   word-wrap@1.2.5: {}
 
@@ -5172,6 +5720,10 @@ snapshots:
   ws@8.18.0: {}
 
   ws@8.20.0: {}
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
 
   yallist@3.1.1: {}
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from "vitest/config";
+
+// Standalone from vite.config.ts on purpose: the Cloudflare and React Router
+// plugins spin up a Workers/SSR environment that unit tests neither need nor
+// can run inside. This config keeps only the `~/*` path resolution the app
+// relies on (via Vite's native tsconfig paths support), and runs tests in
+// jsdom so browser globals (localStorage, DOM) are available to the modules
+// that touch them.
+export default defineConfig({
+  resolve: {
+    tsconfigPaths: true,
+  },
+  test: {
+    environment: "jsdom",
+    globals: true,
+    include: ["app/**/*.{test,spec}.{ts,tsx}"],
+  },
+});


### PR DESCRIPTION
## What

Introduces a unit test suite. The repo previously had only static checks (ESLint, tsc, Prettier) — no test runner and no tests.

- **Vitest + jsdom**, configured in a standalone `vitest.config.ts` kept separate from `vite.config.ts` on purpose: the Cloudflare/React Router plugins boot a Workers/SSR environment that unit tests neither need nor can run inside. Uses Vite's native `resolve.tsconfigPaths` for the `~/*` alias — no extra resolver plugin.
- `pnpm test` (run once) and `pnpm test:watch` scripts.
- **84 tests** colocated as `*.test.ts`, covering the pure, logic-heavy code:
  - `parseReceiptText` — trailing-minus (Costco) discounts, skip-word boundaries (CASHEWS/FONDUE), savings-tally sign handling, charged-vs-restated tax/tip dedup, indented sub-items.
  - `receiptSchema` — `recoverJson` (fences, string-braces, mid-generation truncation recovery) and `fromSchema` (price/amount field fallback, string coercion, `>=10000` rejection).
  - `bill` — `itemTotal`, `canShareBill`, and the newly extracted `computeBreakdowns`.
  - `colors` and the portfolio section `registry`.

## Why the BillSummary refactor

The per-person split and tax/tip apportionment — the app's most important logic — lived inside `BillSummary`'s render body, untestable without scraping dollar amounts out of the DOM. The second commit moves it verbatim into a pure `computeBreakdowns()` in `bill.ts`; `BillSummary` now just renders the result. Its tests cover the edge cases the code comments warn about: weighting tax/tip by positive spend only (so a discounted-only buyer never gets a negative tax share), the even-split fallback when nothing positive was bought, sub-items in the breakdown, and NaN handling.

## Reviewer notes

- Two commits: test infrastructure + pure-util tests, then the `BillSummary` extraction + its tests.
- The refactor is behavior-preserving. Verified in the running app: a \$30 item split between two people with \$8 tax + \$4 tip produces \$21 each / \$42 total, and the expanded card shows Tax \$4.00 / Tip \$2.00 — matching the extracted function exactly.
- **Not covered** (deliberately): canvas/PDF/IndexedDB modules (`prepareReceipt`, `trimReceipt`, `receiptStore`) and presentational/interaction components — the former need heavy browser mocking, the latter would need `@testing-library/react` and mostly assert markup. Happy to add either in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)